### PR TITLE
Separate module for base distributions

### DIFF
--- a/anvil/config.py
+++ b/anvil/config.py
@@ -70,14 +70,12 @@ class ConfigParser(Config):
 
     def produce_generator(
         self,
-        n_batch: int,
         lattice_size: int,
         base_dist: str = "normal",
         field_dimension: int = 1,
     ):
         if base_dist == "normal":
             return NormalDist(
-                n_batch=n_batch,
                 lattice_volume=lattice_size,
                 field_dimension=field_dimension,
             )

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -1,0 +1,69 @@
+"""
+generators.py
+
+Module containing classes corresponding to different base distributions.
+"""
+from math import pi, log, sqrt
+import torch
+
+
+class NormalDist:
+    """
+    Class which handles the generation of a sample of field configurations
+    following the standard normal distribution.
+
+    Intended usage: instantiate class before training phase, passing the
+    batch size as a parameter.
+    The __call__ method can then be re-used during the sampling phase, but
+    with a flexible n_sample parameter to replace n_batch.
+
+    Inputs:
+    -------
+    field_dimension: int
+        Number of independent field components at each lattice site.
+        Default = 1, i.e. a scalar field.
+    lattice_volume: int
+        Number of lattice sites.
+    n_batch: int
+        Batch size for the training phase, where each member of the batch
+        is a field configuration with field_dimension * lattice_volume
+        components.
+    """
+
+    def __init__(self, n_batch, lattice_volume, field_dimension=1):
+        self.n_batch = n_batch
+        self.lattice_volume = lattice_volume
+        self.field_dimension = field_dimension
+
+        # Number of components per field configuration =
+        # size of output Tensor at dimension 1
+        self.size_out = self.lattice_volume * self.field_dimension
+
+        # Pre-calculate normalisation for log density
+        self._log_normalisation = self.log_normalisation()
+
+    def __call__(self, n_sample) -> torch.Tensor:
+        """Return tensor of values drawn from the standard normal distribution
+        with mean 0, variance 1.
+        
+        Return shape: (n_sample, field_dimension * lattice_volume).
+        """
+        return torch.randn(n_sample, self.size_out)
+
+    def log_normalisation(self) -> float:
+        """logarithm of the normalisation for the density function."""
+        print(self.size_out)
+        return log(sqrt(pow(2 * pi, self.size_out)))
+
+    def log_density(self, sample: torch.Tensor) -> torch.Tensor:
+        """Return log probability density of a sample generated from
+        the __call__ method above with default arguments!
+
+        The size of the sample (number of configurations) should be exactly
+        self.n_batch, otherwise the pre-calculated log normalisation will
+        be incorrect.
+
+        Return shape: (n_batch, 1).
+        """
+        exponent = -torch.sum(0.5 * sample.pow(2), dim=1, keepdim=True)
+        return exponent - self._log_normalisation

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -1,5 +1,5 @@
 """
-generators.py
+distributions.py
 
 Module containing classes corresponding to different base distributions.
 """

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -34,7 +34,7 @@ class NormalDist:
         self.size_out = self.lattice_volume * self.field_dimension
 
         # Pre-calculate normalisation for log density
-        self._log_normalisation = self.log_normalisation()
+        self.log_normalisation = self._log_normalisation()
 
     def __call__(self, n_sample) -> torch.Tensor:
         """Return tensor of values drawn from the standard normal distribution
@@ -44,7 +44,7 @@ class NormalDist:
         """
         return torch.randn(n_sample, self.size_out)
 
-    def log_normalisation(self) -> float:
+    def _log_normalisation(self) -> float:
         """logarithm of the normalisation for the density function."""
         return log(sqrt(pow(2 * pi, self.size_out)))
 
@@ -56,4 +56,4 @@ class NormalDist:
         field configurations (the first dimension of sample).
         """
         exponent = -torch.sum(0.5 * sample.pow(2), dim=1, keepdim=True)
-        return exponent - self._log_normalisation
+        return exponent - self.log_normalisation

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -12,10 +12,9 @@ class NormalDist:
     Class which handles the generation of a sample of field configurations
     following the standard normal distribution.
 
-    Intended usage: instantiate class before training phase, passing the
-    batch size as a parameter.
-    The __call__ method can then be re-used during the sampling phase, but
-    with a flexible n_sample parameter to replace n_batch.
+    Intended usage: instantiate class before training phase.
+    The __call__ method can then be used during sampling since this
+    object will be associated with the loaded model.
 
     Inputs:
     -------
@@ -24,14 +23,9 @@ class NormalDist:
         Default = 1, i.e. a scalar field.
     lattice_volume: int
         Number of lattice sites.
-    n_batch: int
-        Batch size for the training phase, where each member of the batch
-        is a field configuration with field_dimension * lattice_volume
-        components.
     """
 
-    def __init__(self, n_batch, lattice_volume, field_dimension=1):
-        self.n_batch = n_batch
+    def __init__(self, lattice_volume, field_dimension=1):
         self.lattice_volume = lattice_volume
         self.field_dimension = field_dimension
 
@@ -52,18 +46,14 @@ class NormalDist:
 
     def log_normalisation(self) -> float:
         """logarithm of the normalisation for the density function."""
-        print(self.size_out)
         return log(sqrt(pow(2 * pi, self.size_out)))
 
     def log_density(self, sample: torch.Tensor) -> torch.Tensor:
         """Return log probability density of a sample generated from
-        the __call__ method above with default arguments!
+        the __call__ method above.
 
-        The size of the sample (number of configurations) should be exactly
-        self.n_batch, otherwise the pre-calculated log normalisation will
-        be incorrect.
-
-        Return shape: (n_batch, 1).
+        Return shape: (n_sample, 1) where n_sample is the number of
+        field configurations (the first dimension of sample).
         """
         exponent = -torch.sum(0.5 * sample.pow(2), dim=1, keepdim=True)
         return exponent - self._log_normalisation

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -294,7 +294,7 @@ class RealNVP(nn.Module):
 
     def inverse_map(self, z_input: torch.Tensor) -> torch.Tensor:
         r"""Function which maps simple distribution, z, to target distribution
-        selfz\phi.
+        \phi.
 
         Parameters
         ----------

--- a/anvil/observables.py
+++ b/anvil/observables.py
@@ -161,14 +161,14 @@ def bootstrap_function(func, states, *args, n_boot=100):
 
 
 def two_point_function(
-    sample_training_output, training_geometry, bootstrap_n_samples=100
+    sample_training_output, training_geometry, n_boot=100
 ):
     """Bootstrap calc_two_point_function, using bootstrap_function"""
     return bootstrap_function(
         calc_two_point_function,
         sample_training_output,
         training_geometry,
-        n_boot=bootstrap_n_samples,
+        n_boot=n_boot,
     )
 
 

--- a/anvil/sample.py
+++ b/anvil/sample.py
@@ -55,9 +55,7 @@ def sample_batch(loaded_model, action, batch_size, current_state=None):
         boolean tensor containing accept/reject history of chain
     """
     with torch.no_grad():  # don't track gradients
-        z = torch.randn(
-            (batch_size + 1, loaded_model.size_in)
-        )  # random z configurations
+        z = loaded_model.generator(batch_size + 1)
         phi = loaded_model.inverse_map(z)  # map using trained loaded_model to phi
         if current_state is not None:
             phi[0] = current_state

--- a/anvil/train.py
+++ b/anvil/train.py
@@ -64,7 +64,7 @@ def train(
                 f"{outpath}/checkpoint_{i}.pt",
             )
         # gen simple states
-        z = torch.randn((n_batch, n_units))
+        z = loaded_model.generator(n_batch)
         phi = loaded_model.inverse_map(z)
         target = action(phi)
         output = loaded_model(phi)


### PR DESCRIPTION
Created a module called distributions.py which currently contains just one class `NormalDist`.

This class does the following
- Handles generation of standard normal variates through the `__call__` method, which is used during both training and sampling.
- Contains method to compute the log density which is used in the loss function during training only.

The `NormDist` object is passed to `RealNVP` under the name `generator`, which I'm not entirely happy with.

It may seem redundant, but I'm finding that this system is easily extensible, since it means we don't have to have base distributions hard-coded into models.

Subsequent PR's will add another class, to distributions.py which deals with uniform distributions on N-spheres, containing methods for e.g. calculating the Jacobian for the spherical parameterisation.