### PR TITLE
Combine inverse map and log density calculation

### DIFF
--- a/anvil/config.py
+++ b/anvil/config.py
@@ -78,8 +78,8 @@ class ConfigParser(Config):
         else:
             raise NotImplementedError
 
-    def produce_model(self, generator, n_affine, network_kwargs):
-        model = RealNVP(generator=generator, n_affine=n_affine, **network_kwargs)
+    def produce_model(self, lattice_size, n_affine, network_kwargs):
+        model = RealNVP(size_in=lattice_size, n_affine=n_affine, **network_kwargs)
         return model
 
     def parse_epochs(self, epochs: int):
@@ -114,8 +114,9 @@ class ConfigParser(Config):
             _, model = self.parse_from_(None, "model", write=False)
             _, action = self.parse_from_(None, "action", write=False)
             _, cps = self.parse_from_(None, "checkpoints", write=False)
+            _, generator = self.parse_from_(None, "generator", write=False)
 
-        return dict(geometry=geometry, model=model, action=action, checkpoints=cps)
+        return dict(geometry=geometry, model=model, action=action, checkpoints=cps, generator=generator)
 
     def produce_training_geometry(self, training_output):
         with self.set_context(ns=self._curr_ns.new_child(training_output.as_input())):

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -69,15 +69,11 @@ class ConfigParser(Config):
         return nb
 
     def produce_generator(
-        self,
-        lattice_size: int,
-        base_dist: str = "normal",
-        field_dimension: int = 1,
+        self, lattice_size: int, base_dist: str = "normal", field_dimension: int = 1,
     ):
         if base_dist == "normal":
             return NormalDist(
-                lattice_volume=lattice_size,
-                field_dimension=field_dimension,
+                lattice_volume=lattice_size, field_dimension=field_dimension,
             )
         else:
             raise NotImplementedError

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -174,10 +174,10 @@ class ConfigParser(Config):
         return interval
 
     def parse_n_boot(self, n_boot: int):
-        if n_samples < 2:
+        if n_boot < 2:
             raise ConfigError("n_boot must be greater than 1")
-        log.warning(f"Using user specified n_boot: {n_samples}")
-        return n_samples
+        log.warning(f"Using user specified n_boot: {n_boot}")
+        return n_boot
 
     @element_of("windows")
     def parse_window(self, window: float):

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -36,7 +36,17 @@ class NormalDist:
         # Pre-calculate normalisation for log density
         self.log_normalisation = self._log_normalisation()
 
-    def __call__(self, n_sample) -> torch.Tensor:
+    def __call__(self, n_sample) -> tuple:
+        """Return a tuple (sample, log_density) for a sample of n_sample states
+        drawn from the standard uniform distribution.
+        
+        See docstrings for instance methods generator, log_density for more details.
+        """
+        sample = self.generator(n_sample)
+        log_density = self.log_density(sample)
+        return (sample, log_density)
+
+    def generator(self, n_sample):
         """Return tensor of values drawn from the standard normal distribution
         with mean 0, variance 1.
         

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -280,7 +280,7 @@ class RealNVP(nn.Module):
         super(RealNVP, self).__init__()
         self.generator = generator
         self.size_in = self.generator.size_out
-        
+
         self.affine_layers = nn.ModuleList(
             [
                 AffineLayer(self.size_in, affine_hidden_shape, affine_hidden_shape, i)
@@ -295,7 +295,8 @@ class RealNVP(nn.Module):
     def forward(self, z_input: torch.Tensor) -> torch.Tensor:
         r"""Function which maps simple distribution, z, to target distribution
         \phi, and at the same time calculates the density of the output
-        distribution using the change of variables formula.
+        distribution using the change of variables formula, according to 
+        eq. (8) of https://arxiv.org/pdf/1904.12072.pdf.
 
         Parameters
         ----------

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -292,9 +292,10 @@ class RealNVP(nn.Module):
         """Function that maps field configuration to simple distribution"""
         raise NotImplementedError
 
-    def inverse_map(self, z_input: torch.Tensor) -> torch.Tensor:
+    def forward(self, z_input: torch.Tensor) -> torch.Tensor:
         r"""Function which maps simple distribution, z, to target distribution
-        \phi.
+        \phi, and at the same time calculates the density of the output
+        distribution using the change of variables formula.
 
         Parameters
         ----------
@@ -303,40 +304,23 @@ class RealNVP(nn.Module):
 
         Returns
         -------
-        out: torch.Tensor
+        phi_out: torch.Tensor
             stack of transformed states, which are drawn from an approximation
             of the target distribution, same shape as input.
-
+        log_density: torch.Tensor
+            logarithm of the probability density of the output distribution,
+            with shape (n_states, 1)
         """
+        # log density of base distribution
+        log_density = self.generator.log_density(z_input)
+
         phi_out = z_input
         for layer in reversed(self.affine_layers):  # reverse layers!
             phi_out = layer.inverse_coupling_layer(phi_out)
+            log_density += layer.log_det_jacobian(phi_out).view(-1, 1)
             # TODO: make this yield, then make a yield from wrapper?
-        return phi_out
 
-    def forward(self, phi_input: torch.Tensor) -> torch.Tensor:
-        r"""Returns the log of the exact probability (of model) associated with
-        each of the input states according to eq. (8) of
-        https://arxiv.org/pdf/1904.12072.pdf.
-
-        Parameters
-        ----------
-        phi_input: torch.Tensor
-            stack of input states, shape (N_states, D)
-
-        Returns
-        -------
-        out: torch.Tensor
-            column of log(\tilde p) associated with each of input states
-
-        """
-        log_jacob_contr = torch.zeros(phi_input.size()[0], 1)
-        z_out = phi_input
-        for layer in self.affine_layers:
-            log_jacob_contr += layer.log_det_jacobian(z_out).view(-1, 1)
-            z_out = layer(z_out)
-        log_simple_prob = self.generator.log_density(z_out)
-        return log_simple_prob + log_jacob_contr
+        return phi_out, log_density
 
 
 if __name__ == "__main__":

--- a/anvil/sample.py
+++ b/anvil/sample.py
@@ -60,6 +60,7 @@ def sample_batch(
         phi, log_density = loaded_model(z)  # map using trained loaded_model to phi
         if current_state is not None:
             phi[0] = current_state
+            log_density[0] = current_log_density
 
     history = torch.zeros(batch_size, dtype=torch.bool)  # accept/reject history
     chain_indices = torch.zeros(batch_size, dtype=torch.long)
@@ -80,7 +81,7 @@ def sample_batch(
         else:  # rejected
             chain_indices[j - 1] = i
 
-    return phi[chain_indices, :], log_density[chain_indices, :][-1, :], history
+    return phi[chain_indices, :], log_density[chain_indices][-1], history
 
 
 def thermalised_state(loaded_model, action, thermalisation) -> torch.Tensor:

--- a/anvil/sample.py
+++ b/anvil/sample.py
@@ -21,7 +21,9 @@ class LogRatioNanError(Exception):
     pass
 
 
-def sample_batch(loaded_model, action, batch_size, current_state=None, current_log_density=None):
+def sample_batch(
+    loaded_model, action, batch_size, current_state=None, current_log_density=None
+):
     r"""
     Sample using Metroplis-Hastings algorithm from a large number of phi
     configurations.
@@ -58,7 +60,7 @@ def sample_batch(loaded_model, action, batch_size, current_state=None, current_l
         phi, log_density = loaded_model(z)  # map using trained loaded_model to phi
         if current_state is not None:
             phi[0] = current_state
-    
+
     history = torch.zeros(batch_size, dtype=torch.bool)  # accept/reject history
     chain_indices = torch.zeros(batch_size, dtype=torch.long)
 

--- a/anvil/train.py
+++ b/anvil/train.py
@@ -10,7 +10,9 @@ import torch
 import torch.optim as optim
 
 
-def shifted_kl(model_log_density: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+def shifted_kl(
+    model_log_density: torch.Tensor, target_log_density: torch.Tensor
+) -> torch.Tensor:
     r"""Sample mean of the shifted Kullbach-Leibler divergence between target
     and model distribution.
 
@@ -19,8 +21,10 @@ def shifted_kl(model_log_density: torch.Tensor, action: torch.Tensor) -> torch.T
     model_log_density: torch.Tensor
         column of log (\tilde p) for a sample of states, which is returned by
         forward pass of `RealNVP` model
-    action: torch.Tensor
-        column of actions S(\phi) for set of sample states
+    target_log_density: torch.Tensor
+        column of log(p) for a sample of states, which includes the negative action
+        -S(\phi) and a possible contribution for the volume element due to a
+        non-trivial parameterisation.
 
     Returns
     -------
@@ -29,11 +33,12 @@ def shifted_kl(model_log_density: torch.Tensor, action: torch.Tensor) -> torch.T
         shifted K-L for set of sample states.
 
     """
-    return torch.mean(model_log_density + action, dim=0)
+    return torch.mean(model_log_density - target_log_density, dim=0)
 
 
 def train(
     loaded_model,
+    generator,
     action,
     *,
     train_range,
@@ -51,7 +56,7 @@ def train(
     )
     # let's use tqdm to see progress
     pbar = tqdm(range(*train_range), desc=f"loss: {current_loss}")
-    n_units = loaded_model.size_in
+    n_units = generator.size_out
     for i in pbar:
         if (i % save_interval) == 0:
             torch.save(
@@ -64,12 +69,14 @@ def train(
                 f"{outpath}/checkpoint_{i}.pt",
             )
         # gen simple states
-        z = loaded_model.generator(n_batch)
-        phi, model_log_density = loaded_model(z)
-        target = action(phi)
+        z, base_log_density = generator(n_batch)
+        phi, map_log_density = loaded_model(z)
+
+        model_log_density = base_log_density + map_log_density
+        target_log_density = -action(phi)  # term from parameterisatiom goes here
 
         loaded_model.zero_grad()  # get rid of stored gradients
-        current_loss = shifted_kl(model_log_density, target)
+        current_loss = shifted_kl(model_log_density, target_log_density)
         current_loss.backward()  # calc gradients
 
         loaded_optimizer.step()

--- a/anvil/train.py
+++ b/anvil/train.py
@@ -10,13 +10,13 @@ import torch
 import torch.optim as optim
 
 
-def shifted_kl(log_tilde_p: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+def shifted_kl(model_log_density: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
     r"""Sample mean of the shifted Kullbach-Leibler divergence between target
     and model distribution.
 
     Parameters
     ----------
-    log_tilde_p: torch.Tensor
+    model_log_density: torch.Tensor
         column of log (\tilde p) for a sample of states, which is returned by
         forward pass of `RealNVP` model
     action: torch.Tensor
@@ -29,7 +29,7 @@ def shifted_kl(log_tilde_p: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
         shifted K-L for set of sample states.
 
     """
-    return torch.mean(log_tilde_p + action, dim=0)
+    return torch.mean(model_log_density + action, dim=0)
 
 
 def train(
@@ -65,12 +65,11 @@ def train(
             )
         # gen simple states
         z = loaded_model.generator(n_batch)
-        phi, output = loaded_model(z)
+        phi, model_log_density = loaded_model(z)
         target = action(phi)
-        #output = loaded_model(phi)
 
         loaded_model.zero_grad()  # get rid of stored gradients
-        current_loss = shifted_kl(output, target)
+        current_loss = shifted_kl(model_log_density, target)
         current_loss.backward()  # calc gradients
 
         loaded_optimizer.step()

--- a/anvil/train.py
+++ b/anvil/train.py
@@ -65,9 +65,9 @@ def train(
             )
         # gen simple states
         z = loaded_model.generator(n_batch)
-        phi = loaded_model.inverse_map(z)
+        phi, output = loaded_model(z)
         target = action(phi)
-        output = loaded_model(phi)
+        #output = loaded_model(phi)
 
         loaded_model.zero_grad()  # get rid of stored gradients
         current_loss = shifted_kl(output, target)


### PR DESCRIPTION
Combined the inverse map from base to target distribution with the calculation of the model density.
This avoids going explicitly applying the forward map to calculate the density, as was being done before.

**Justification:**
- Speed, primarily. For the example `phi4_train.yml` runcard, it takes 1.5x longer to train for the same number of epochs when the density is calculated separately, compared to when it is merged into the inverse map. This is true for `RealNVP` for which the map and inverse are very cheap to compute, but the speed gains will be bigger for a more complicated map.
- I think this slightly simplifies the task of combining different modules. For example, we want to sandwich `RealNVP` between a projection map and its inverse, which could be easily implemented in another `torch.nn.Module` which includes a single call to `RealNVP.forward()`, rather than needing to call `inverse_map()` and `forward()` separately.

**Drawbacks:**
- Sampling is now slightly messier, with the current log density needing to be passed between batches in addition to the current state.
- Slight reduction in transparency.