### PR TITLE
Bootstrap function loops over batches

### DIFF
--- a/anvil/config.py
+++ b/anvil/config.py
@@ -174,10 +174,10 @@ class ConfigParser(Config):
         return interval
 
     def parse_n_boot(self, n_boot: int):
-        if n_samples < 2:
+        if n_boot < 2:
             raise ConfigError("n_boot must be greater than 1")
-        log.warning(f"Using user specified n_boot: {n_samples}")
-        return n_samples
+        log.warning(f"Using user specified n_boot: {n_boot}")
+        return n_boot
 
     @element_of("windows")
     def parse_window(self, window: float):

--- a/anvil/observables.py
+++ b/anvil/observables.py
@@ -14,7 +14,6 @@ from scipy.signal import correlate
 import torch
 
 from tqdm import tqdm
-from time import time
 
 
 def arcosh(x):

--- a/anvil/observables.py
+++ b/anvil/observables.py
@@ -13,8 +13,6 @@ import numpy as np
 from scipy.signal import correlate
 import torch
 
-from tqdm import tqdm
-
 
 def arcosh(x):
     """Inverse hyperbolic cosine function for torch.Tensor arguments.
@@ -148,21 +146,15 @@ def bootstrap_function(func, states, *args, n_boot=100):
         dimension
 
     """
-    # NOTE: Optimal seems to be around n_sample x batch_size = 10000 for
-    # calc_two_point_function on my laptop. Clearly this is not a general
-    # rule though.
     sample_size = states.shape[0]
-    batch_size = min(n_boot, max(1, 10000 // sample_size))
-    n_batch = n_boot // batch_size
 
-    pbar = tqdm(range(n_batch), desc="bootstrap batch")
     res = []
-    for n in pbar:
-        boot_index = torch.randint(0, sample_size, size=(sample_size, batch_size))
-        resampled_states = states[boot_index, :].transpose(1, 2)
+    for resample in range(n_boot):
+        boot_index = torch.randint(0, sample_size, size=(sample_size,))
+        resampled_states = states[boot_index, :]
         res.append(func(resampled_states, *args))
 
-    return torch.cat(res, dim=-1)
+    return torch.stack(res, dim=-1)
 
 
 def two_point_function(sample_training_output, training_geometry, n_boot=100):


### PR DESCRIPTION
Although vectorizing as much as possible is a good thing, we seemed to have slightly overstepped with the bootstrap function in that, for reasonable sample and bootstrap sample sizes, it tries to allocate more memory than is available on a typical laptop.

This is a pretty rough-and-ready fix which will do for the time being, though perhaps more sophisticated memory handling will be required in the future... gulp.

#### Timings
Here are some results for the time spent in `bootstrap_function`, using the example `phi4_sample.yml` runcard (6x6 lattice). Note that a bootstrap batch size equal to `n_boot` is just the old implementation.

| `target_length` | `n_boot` | bootstrap batch size | time spent in `bootstrap_function` |
| :---: | :---: | :---: | :---: |
| 1000 | 1000 | 1000 | 18s |
| 1000 | 1000 | 100 | 8.3s |
| 1000 | 1000 | 10 | 6.8s |
| 1000 | 1000 | 1 | 8.4s |
| 10000 | 1000 | 1000 | 10 mins (!) |
| 10000 | 1000 | 100 | 200s |
| 10000 | 1000 | 10 |  90s |
| 10000 | 1000 | 1 | 50s |

I noticed that pytorch normally uses at least 4 of my laptop's cores, but that dropped to just one for the 10 minute example which was using almost 30% of my RAM. It would be nice to understand this behaviour.