### PR TITLE
More flexibility with specifying target distribution and flow model in runcard

### DIFF
--- a/anvil/config.py
+++ b/anvil/config.py
@@ -8,13 +8,12 @@ import logging
 from reportengine.report import Config
 from reportengine.configparser import ConfigError, element_of
 
-from anvil.core import PhiFourAction, TrainingOutput
+from anvil.core import Target, TrainingOutput
 from anvil.models import RealNVP
 from anvil.geometry import Geometry2D
 from anvil.distributions import NormalDist
 
 log = logging.getLogger(__name__)
-
 
 class ConfigParser(Config):
     """Extend the reportengine Config class for anvil-specific
@@ -37,18 +36,15 @@ class ConfigParser(Config):
     def produce_geometry(self, lattice_length):
         return Geometry2D(lattice_length)
 
-    def parse_m_sq(self, m: (float, int)):
-        return m
+    def parse_theory(self, theo: str):
+        return theo
 
-    def parse_lam(self, lam: (float, int)):
-        return lam
+    def parse_theory_parameters(self, params: dict):
+        return params
 
-    def parse_use_arxiv_version(self, do_use: bool):
-        return do_use
-
-    def produce_action(self, m_sq, lam, geometry, use_arxiv_version):
-        return PhiFourAction(
-            m_sq, lam, geometry=geometry, use_arxiv_version=use_arxiv_version
+    def produce_target(self, theory, theory_parameters, geometry):
+        return Target(
+            theory=theory, theory_parameters=theory_parameters, geometry=geometry
         )
 
     def parse_hidden_nodes(self, hid_spec):
@@ -68,7 +64,7 @@ class ConfigParser(Config):
     def parse_n_batch(self, nb: int):
         return nb
 
-    def produce_generator(
+    def produce_base(
         self, lattice_size: int, base_dist: str = "normal", field_dimension: int = 1,
     ):
         if base_dist == "normal":
@@ -112,11 +108,17 @@ class ConfigParser(Config):
         with self.set_context(ns=self._curr_ns.new_child(training_output.as_input())):
             _, geometry = self.parse_from_(None, "geometry", write=False)
             _, model = self.parse_from_(None, "model", write=False)
-            _, action = self.parse_from_(None, "action", write=False)
+            _, target = self.parse_from_(None, "target", write=False)
             _, cps = self.parse_from_(None, "checkpoints", write=False)
-            _, generator = self.parse_from_(None, "generator", write=False)
+            _, base = self.parse_from_(None, "base", write=False)
 
-        return dict(geometry=geometry, model=model, action=action, checkpoints=cps, generator=generator)
+        return dict(
+            geometry=geometry,
+            model=model,
+            target=target,
+            checkpoints=cps,
+            base=base,
+        )
 
     def produce_training_geometry(self, training_output):
         with self.set_context(ns=self._curr_ns.new_child(training_output.as_input())):

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -122,8 +122,8 @@ class ConfigParser(Config):
         # file - hopefully doesn't cause any issues..
         return training_output.as_input()
 
-    def produce_training_geometry(self, training_output):
-        with self.set_context(ns=self._curr_ns.new_child(training_output.as_input())):
+    def produce_training_geometry(self, training_context):
+        with self.set_context(ns=self._curr_ns.new_child(training_context)):
             _, geometry = self.parse_from_(None, "geometry", write=False)
         return geometry
 

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -78,8 +78,8 @@ class ConfigParser(Config):
         else:
             raise NotImplementedError
 
-    def produce_model(self, generator, n_affine, network_kwargs):
-        model = RealNVP(generator=generator, n_affine=n_affine, **network_kwargs)
+    def produce_model(self, lattice_size, n_affine, network_kwargs):
+        model = RealNVP(size_in=lattice_size, n_affine=n_affine, **network_kwargs)
         return model
 
     def parse_epochs(self, epochs: int):
@@ -114,8 +114,9 @@ class ConfigParser(Config):
             _, model = self.parse_from_(None, "model", write=False)
             _, action = self.parse_from_(None, "action", write=False)
             _, cps = self.parse_from_(None, "checkpoints", write=False)
+            _, generator = self.parse_from_(None, "generator", write=False)
 
-        return dict(geometry=geometry, model=model, action=action, checkpoints=cps)
+        return dict(geometry=geometry, model=model, action=action, checkpoints=cps, generator=generator)
 
     def produce_training_geometry(self, training_output):
         with self.set_context(ns=self._curr_ns.new_child(training_output.as_input())):

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -69,15 +69,11 @@ class ConfigParser(Config):
         return nb
 
     def produce_generator(
-        self,
-        lattice_size: int,
-        base_dist: str = "normal",
-        field_dimension: int = 1,
+        self, lattice_size: int, base_dist: str = "normal", field_dimension: int = 1,
     ):
         if base_dist == "normal":
             return NormalDist(
-                lattice_volume=lattice_size,
-                field_dimension=field_dimension,
+                lattice_volume=lattice_size, field_dimension=field_dimension,
             )
         else:
             raise NotImplementedError

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -6,12 +6,12 @@ Module to parse runcards
 import logging
 
 from reportengine.report import Config
-from reportengine.configparser import ConfigError, element_of
+from reportengine.configparser import ConfigError, element_of, explicit_node
 
-from anvil.core import Target, TrainingOutput
+from anvil.core import TrainingOutput
 from anvil.models import RealNVP
 from anvil.geometry import Geometry2D
-from anvil.distributions import NormalDist
+from anvil.distributions import normal_distribution, phi_four_action
 
 log = logging.getLogger(__name__)
 
@@ -36,15 +36,24 @@ class ConfigParser(Config):
     def produce_geometry(self, lattice_length):
         return Geometry2D(lattice_length)
 
-    def parse_theory(self, theo: str):
-        return theo
+    def parse_theory(self, theory: str):
+        return theory
 
-    def parse_theory_parameters(self, params: dict):
-        return params
+    def parse_m_sq(self, m: (float, int)):
+        return m
 
-    def produce_target(self, theory, theory_parameters, geometry):
-        return Target(
-            theory=theory, theory_parameters=theory_parameters, geometry=geometry
+    def parse_lam(self, lam: (float, int)):
+        return lam
+
+    @explicit_node
+    def produce_target(self, theory):
+        """Return the function which initialises the correct action"""
+        if theory == "phi_four":
+            return phi_four_action
+        raise ConfigError(
+            f"Selected theory: {theory}, has not been implemented yet",
+            theory,
+            ["phi_four"],
         )
 
     def parse_hidden_nodes(self, hid_spec):
@@ -64,15 +73,16 @@ class ConfigParser(Config):
     def parse_n_batch(self, nb: int):
         return nb
 
-    def produce_base(
-        self, lattice_size: int, base_dist: str = "normal", field_dimension: int = 1,
-    ):
+    @explicit_node
+    def produce_base(self, base_dist: str = "normal",):
+        """Return the action which loads appropriate base distribution"""
         if base_dist == "normal":
-            return NormalDist(
-                lattice_volume=lattice_size, field_dimension=field_dimension,
-            )
-        else:
-            raise NotImplementedError
+            return normal_distribution
+        raise ConfigError(
+            f"Base distribution: {base_dist}, has not been implemented yet",
+            base_dist,
+            ["normal"],
+        )
 
     def produce_model(self, lattice_size, n_affine, network_kwargs):
         model = RealNVP(size_in=lattice_size, n_affine=n_affine, **network_kwargs)
@@ -105,20 +115,9 @@ class ConfigParser(Config):
 
     def produce_training_context(self, training_output):
         """Given a training output produce the context of that training"""
-        with self.set_context(ns=self._curr_ns.new_child(training_output.as_input())):
-            _, geometry = self.parse_from_(None, "geometry", write=False)
-            _, model = self.parse_from_(None, "model", write=False)
-            _, target = self.parse_from_(None, "target", write=False)
-            _, cps = self.parse_from_(None, "checkpoints", write=False)
-            _, base = self.parse_from_(None, "base", write=False)
-
-        return dict(
-            geometry=geometry,
-            model=model,
-            target=target,
-            checkpoints=cps,
-            base=base,
-        )
+        # NOTE: This seems a bit hacky, exposing the entire training configuration
+        # file - hopefully doesn't cause any issues..
+        return training_output.as_input()
 
     def produce_training_geometry(self, training_output):
         with self.set_context(ns=self._curr_ns.new_child(training_output.as_input())):
@@ -129,7 +128,7 @@ class ConfigParser(Config):
         valid_optimizers = ("adam", "adadelta")
         if optim not in valid_optimizers:
             raise ConfigError(
-                f"optimizer must be one of {', '.join([opt for opt in valid_optimizers])}"
+                f"Invalid optimizer choice: {optim}", optim, valid_optimizers
             )
         return optim
 

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -45,6 +45,9 @@ class ConfigParser(Config):
     def parse_lam(self, lam: (float, int)):
         return lam
 
+    def parse_use_arxiv_version(self, do_use: bool):
+        return do_use
+
     @explicit_node
     def produce_target(self, theory):
         """Return the function which initialises the correct action"""

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -174,10 +174,10 @@ class ConfigParser(Config):
         return interval
 
     def parse_n_boot(self, n_boot: int):
-        if n_samples < 2:
+        if n_boot < 2:
             raise ConfigError("n_boot must be greater than 1")
-        log.warning(f"Using user specified n_boot: {n_samples}")
-        return n_samples
+        log.warning(f"Using user specified n_boot: {n_boot}")
+        return n_boot
 
     @element_of("windows")
     def parse_window(self, window: float):

--- a/anvil/core.py
+++ b/anvil/core.py
@@ -24,6 +24,30 @@ class TrainingRuncardNotFound(InvalidTrainingOutputError):
     pass
 
 
+class Target:
+    """Defines the target distribution by the logarithm of it's probability
+    density function.
+
+    The general form of the target probability density should a product over
+    all lattice sites of 
+
+                    | \det J(\phi) | exp( -S(\phi) )
+                    
+    where S(\phi) is the lattice action for the theory, and J(\phi) is a
+    Jacobian matrix which may arise if the parameterisation of the fields
+    in terms of \phi is non-trivial.
+    """
+
+    def __init__(self, theory, theory_parameters, geometry):
+        if theory == "phi_four":
+            self.action = PhiFourAction(geometry, **theory_parameters)
+
+        # define contribution to log density from parameterisation here
+
+    def log_density(self, sample: torch.Tensor) -> torch.Tensor:
+        return -self.action(sample)
+
+
 class PhiFourAction(nn.Module):
     """Extend the nn.Module class to return the phi^4 action given either
     a single state size (1, length * length) or a stack of N states
@@ -66,7 +90,7 @@ class PhiFourAction(nn.Module):
 
     """
 
-    def __init__(self, m_sq, lam, geometry, use_arxiv_version=False):
+    def __init__(self, geometry, *, m_sq, lam, use_arxiv_version=False):
         super(PhiFourAction, self).__init__()
         self.geometry = geometry
         self.shift = self.geometry.get_shift()

--- a/anvil/core.py
+++ b/anvil/core.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from glob import glob
 
 import torch
-import torch.nn as nn
 
 from reportengine.compat import yaml
 
@@ -22,104 +21,6 @@ class InvalidTrainingOutputError(Exception):
 
 class TrainingRuncardNotFound(InvalidTrainingOutputError):
     pass
-
-
-class Target:
-    """Defines the target distribution by the logarithm of it's probability
-    density function.
-
-    The general form of the target probability density should a product over
-    all lattice sites of 
-
-                    | \det J(\phi) | exp( -S(\phi) )
-                    
-    where S(\phi) is the lattice action for the theory, and J(\phi) is a
-    Jacobian matrix which may arise if the parameterisation of the fields
-    in terms of \phi is non-trivial.
-    """
-
-    def __init__(self, theory, theory_parameters, geometry):
-        if theory == "phi_four":
-            self.action = PhiFourAction(geometry, **theory_parameters)
-
-        # define contribution to log density from parameterisation here
-
-    def log_density(self, sample: torch.Tensor) -> torch.Tensor:
-        return -self.action(sample)
-
-
-class PhiFourAction(nn.Module):
-    """Extend the nn.Module class to return the phi^4 action given either
-    a single state size (1, length * length) or a stack of N states
-    (N, length * length). See Notes about action definition.
-
-    Parameters
-    ----------
-    geometry:
-        define the geometry of the lattice, including dimension, size and
-        how the state is split into two parts
-    m_sq: float
-        the value of the bare mass squared
-    lam: float
-        the value of the bare coupling
-
-    Examples
-    --------
-    Consider the toy example of the action acting on a random state
-
-    >>> action = PhiFourAction(2, 1, 1)
-    >>> state = torch.rand((1, 2*2))
-    >>> action(state)
-    tensor([[0.9138]])
-
-    Now consider a stack of states
-
-    >>> stack_of_states = torch.rand((5, 2*2))
-    >>> action(stack_of_states)
-    tensor([[3.7782],
-            [2.8707],
-            [4.0511],
-            [2.2342],
-            [2.6494]])
-
-    Notes
-    -----
-    that this is the action as defined in
-    https://doi.org/10.1103/PhysRevD.100.034515 which might differ from the
-    current version on the arxiv.
-
-    """
-
-    def __init__(self, geometry, *, m_sq, lam, use_arxiv_version=False):
-        super(PhiFourAction, self).__init__()
-        self.geometry = geometry
-        self.shift = self.geometry.get_shift()
-        self.lam = lam
-        self.m_sq = m_sq
-        self.length = self.geometry.length
-        if use_arxiv_version:
-            self.version_factor = 2
-        else:
-            self.version_factor = 1
-
-    def forward(self, phi_state: torch.Tensor) -> torch.Tensor:
-        """Perform forward pass, returning action for stack of states.
-
-        see class Notes for details on definition of action.
-        """
-        action = (
-            self.version_factor * (2 + 0.5 * self.m_sq) * phi_state ** 2  # phi^2 terms
-            + self.lam * phi_state ** 4  # phi^4 term
-            - self.version_factor
-            * torch.sum(
-                phi_state[:, self.shift] * phi_state.view(-1, 1, self.length ** 2),
-                dim=1,
-            )  # derivative
-        ).sum(
-            dim=1, keepdim=True  # sum across sites
-        )
-        return action
-
 
 class Checkpoint:
     """Class which saves and loads checkpoints and allows checkpoints to be

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -44,7 +44,7 @@ class NormalDist:
         """
         sample = self.generator(n_sample)
         log_density = self.log_density(sample)
-        return (sample, log_density)
+        return sample, log_density
 
     def generator(self, n_sample):
         """Return tensor of values drawn from the standard normal distribution

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -5,6 +5,7 @@ Module containing classes corresponding to different base distributions.
 """
 from math import pi, log, sqrt
 import torch
+import torch.nn as nn
 
 
 class NormalDist:
@@ -67,3 +68,90 @@ class NormalDist:
         """
         exponent = -torch.sum(0.5 * sample.pow(2), dim=1, keepdim=True)
         return exponent - self.log_normalisation
+
+def normal_distribution(lattice_size, field_dimension=1):
+    """returns an instance of the NormalDist class"""
+    return NormalDist(
+        lattice_volume=lattice_size, field_dimension=field_dimension,
+    )
+
+class PhiFourAction(nn.Module):
+    """Extend the nn.Module class to return the phi^4 action given either
+    a single state size (1, length * length) or a stack of N states
+    (N, length * length). See Notes about action definition.
+
+    The forward pass returns the corresponding log density (unnormalised) which
+    is equal to -S
+
+    Parameters
+    ----------
+    geometry:
+        define the geometry of the lattice, including dimension, size and
+        how the state is split into two parts
+    m_sq: float
+        the value of the bare mass squared
+    lam: float
+        the value of the bare coupling
+
+    Examples
+    --------
+    Consider the toy example of this class acting on a random state
+
+    >>> geom = Geometry2D(2)
+    >>> action = PhiFourAction(1, 1, geom)
+    >>> state = torch.rand((1, 2*2))
+    >>> action(state)
+    tensor([[-2.3838]])
+    >>> state = torch.rand((5, 2*2))
+    >>> action(state)
+    tensor([[-3.9087],
+            [-2.2697],
+            [-2.3940],
+            [-2.3499],
+            [-1.9730]])
+
+    Notes
+    -----
+    that this is the action as defined in
+    https://doi.org/10.1103/PhysRevD.100.034515 which might differ from the
+    current version on the arxiv.
+
+    """
+
+    def __init__(self, m_sq, lam, geometry, use_arxiv_version=False):
+        super(PhiFourAction, self).__init__()
+        self.geometry = geometry
+        self.shift = self.geometry.get_shift()
+        self.lam = lam
+        self.m_sq = m_sq
+        self.length = self.geometry.length
+        if use_arxiv_version:
+            self.version_factor = 2
+        else:
+            self.version_factor = 1
+
+    def forward(self, phi_state: torch.Tensor) -> torch.Tensor:
+        """Perform forward pass, returning -action for stack of states. Note
+        here the minus sign since we want to return the log density of the
+        corresponding unnormalised distribution
+
+        see class Notes for details on definition of action.
+        """
+        action = (
+            self.version_factor * (2 + 0.5 * self.m_sq) * phi_state ** 2  # phi^2 terms
+            + self.lam * phi_state ** 4  # phi^4 term
+            - self.version_factor
+            * torch.sum(
+                phi_state[:, self.shift] * phi_state.view(-1, 1, self.length ** 2),
+                dim=1,
+            )  # derivative
+        ).sum(
+            dim=1, keepdim=True  # sum across sites
+        )
+        return -action
+
+def phi_four_action(m_sq, lam, geometry, use_arxiv_version):
+    """returns instance of PhiFourAction"""
+    return PhiFourAction(
+        m_sq, lam, geometry=geometry, use_arxiv_version=use_arxiv_version
+    )

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -36,7 +36,17 @@ class NormalDist:
         # Pre-calculate normalisation for log density
         self.log_normalisation = self._log_normalisation()
 
-    def __call__(self, n_sample) -> torch.Tensor:
+    def __call__(self, n_sample) -> tuple:
+        """Return a tuple (sample, log_density) for a sample of n_sample states
+        drawn from the standard uniform distribution.
+        
+        See docstrings for instance methods generator, log_density for more details.
+        """
+        sample = self.generator(n_sample)
+        log_density = self.log_density(sample)
+        return (sample, log_density)
+
+    def generator(self, n_sample):
         """Return tensor of values drawn from the standard normal distribution
         with mean 0, variance 1.
         

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -280,7 +280,7 @@ class RealNVP(nn.Module):
         super(RealNVP, self).__init__()
         self.generator = generator
         self.size_in = self.generator.size_out
-        
+
         self.affine_layers = nn.ModuleList(
             [
                 AffineLayer(self.size_in, affine_hidden_shape, affine_hidden_shape, i)
@@ -295,7 +295,8 @@ class RealNVP(nn.Module):
     def forward(self, z_input: torch.Tensor) -> torch.Tensor:
         r"""Function which maps simple distribution, z, to target distribution
         \phi, and at the same time calculates the density of the output
-        distribution using the change of variables formula.
+        distribution using the change of variables formula, according to 
+        eq. (8) of https://arxiv.org/pdf/1904.12072.pdf.
 
         Parameters
         ----------

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -292,9 +292,10 @@ class RealNVP(nn.Module):
         """Function that maps field configuration to simple distribution"""
         raise NotImplementedError
 
-    def inverse_map(self, z_input: torch.Tensor) -> torch.Tensor:
+    def forward(self, z_input: torch.Tensor) -> torch.Tensor:
         r"""Function which maps simple distribution, z, to target distribution
-        \phi.
+        \phi, and at the same time calculates the density of the output
+        distribution using the change of variables formula.
 
         Parameters
         ----------
@@ -303,40 +304,23 @@ class RealNVP(nn.Module):
 
         Returns
         -------
-        out: torch.Tensor
+        phi_out: torch.Tensor
             stack of transformed states, which are drawn from an approximation
             of the target distribution, same shape as input.
-
+        log_density: torch.Tensor
+            logarithm of the probability density of the output distribution,
+            with shape (n_states, 1)
         """
+        # log density of base distribution
+        log_density = self.generator.log_density(z_input)
+
         phi_out = z_input
         for layer in reversed(self.affine_layers):  # reverse layers!
             phi_out = layer.inverse_coupling_layer(phi_out)
+            log_density += layer.log_det_jacobian(phi_out).view(-1, 1)
             # TODO: make this yield, then make a yield from wrapper?
-        return phi_out
 
-    def forward(self, phi_input: torch.Tensor) -> torch.Tensor:
-        r"""Returns the log of the exact probability (of model) associated with
-        each of the input states according to eq. (8) of
-        https://arxiv.org/pdf/1904.12072.pdf.
-
-        Parameters
-        ----------
-        phi_input: torch.Tensor
-            stack of input states, shape (N_states, D)
-
-        Returns
-        -------
-        out: torch.Tensor
-            column of log(\tilde p) associated with each of input states
-
-        """
-        log_jacob_contr = torch.zeros(phi_input.size()[0], 1)
-        z_out = phi_input
-        for layer in self.affine_layers:
-            log_jacob_contr += layer.log_det_jacobian(z_out).view(-1, 1)
-            z_out = layer(z_out)
-        log_simple_prob = self.generator.log_density(z_out)
-        return log_simple_prob + log_jacob_contr
+        return phi_out, log_density
 
 
 if __name__ == "__main__":

--- a/anvil/sample.py
+++ b/anvil/sample.py
@@ -72,7 +72,7 @@ def sample_batch(
     history = torch.zeros(batch_size, dtype=torch.bool)  # accept/reject history
     chain_indices = torch.zeros(batch_size, dtype=torch.long)
 
-    log_ratio = model_log_density - target.log_density(phi)
+    log_ratio = model_log_density - target(phi)
     if not isfinite(exp(float(min(log_ratio) - max(log_ratio)))):
         raise LogRatioNanError(
             "could run into nans based on minimum and maximum log of ratio of probabilities"

--- a/anvil/sample.py
+++ b/anvil/sample.py
@@ -46,8 +46,8 @@ def sample_batch(
     loaded_model: Module
         loaded_model which is going to be used to generate sample states
     target: Module
-        the target upon which the loaded_model was trained, used to calculate the
-        acceptance condition
+        the target distribution with which the loaded_model was trained,
+        used to calculate the acceptance condition
     batch_size: int
         the number of states to generate from the loaded_model
     current_state: torch.Tensor or None
@@ -100,8 +100,8 @@ def thermalised_state(loaded_model, base, target, thermalisation) -> torch.Tenso
     loaded_model: Module
         loaded_model which is going to be used to generate sample states
     target: Module
-        the target upon which the loaded_model was trained, used to calculate the
-        acceptance condition
+        the target distribution with which the loaded_model was trained,
+        used to calculate the acceptance condition
 
     Returns
     -------
@@ -149,8 +149,8 @@ def chain_autocorrelation(
     loaded_model: Module
         loaded_model which is going to be used to generate sample states
     target: Module
-        the target upon which the loaded_model was trained, used to calculate the
-        acceptance condition
+        the target distribution with which the loaded_model was trained,
+        used to calculate the acceptance condition
     initial_state:
         the current state of the Markov chain, after thermalisation
 
@@ -232,12 +232,7 @@ def sample(
     Returns
     -------
     decorrelated_chain: torch.Tensor
-<<<<<<< HEAD
         a sample of states from loaded_model, size = (target_length, base.size_out)
-=======
-        a sample of states from loaded_model, size = (target_length, generator.size_out)
->>>>>>> master
-
     """
 
     # Thermalise

--- a/anvil/sample.py
+++ b/anvil/sample.py
@@ -60,6 +60,7 @@ def sample_batch(
         phi, log_density = loaded_model(z)  # map using trained loaded_model to phi
         if current_state is not None:
             phi[0] = current_state
+            log_density[0] = current_log_density
 
     history = torch.zeros(batch_size, dtype=torch.bool)  # accept/reject history
     chain_indices = torch.zeros(batch_size, dtype=torch.long)
@@ -80,7 +81,7 @@ def sample_batch(
         else:  # rejected
             chain_indices[j - 1] = i
 
-    return phi[chain_indices, :], log_density[chain_indices, :][-1, :], history
+    return phi[chain_indices, :], log_density[chain_indices][-1], history
 
 
 def thermalised_state(loaded_model, action, thermalisation) -> torch.Tensor:

--- a/anvil/sample.py
+++ b/anvil/sample.py
@@ -21,7 +21,9 @@ class LogRatioNanError(Exception):
     pass
 
 
-def sample_batch(loaded_model, action, batch_size, current_state=None, current_log_density=None):
+def sample_batch(
+    loaded_model, action, batch_size, current_state=None, current_log_density=None
+):
     r"""
     Sample using Metroplis-Hastings algorithm from a large number of phi
     configurations.
@@ -58,7 +60,7 @@ def sample_batch(loaded_model, action, batch_size, current_state=None, current_l
         phi, log_density = loaded_model(z)  # map using trained loaded_model to phi
         if current_state is not None:
             phi[0] = current_state
-    
+
     history = torch.zeros(batch_size, dtype=torch.bool)  # accept/reject history
     chain_indices = torch.zeros(batch_size, dtype=torch.long)
 

--- a/anvil/train.py
+++ b/anvil/train.py
@@ -10,7 +10,9 @@ import torch
 import torch.optim as optim
 
 
-def shifted_kl(model_log_density: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+def shifted_kl(
+    model_log_density: torch.Tensor, target_log_density: torch.Tensor
+) -> torch.Tensor:
     r"""Sample mean of the shifted Kullbach-Leibler divergence between target
     and model distribution.
 
@@ -19,8 +21,10 @@ def shifted_kl(model_log_density: torch.Tensor, action: torch.Tensor) -> torch.T
     model_log_density: torch.Tensor
         column of log (\tilde p) for a sample of states, which is returned by
         forward pass of `RealNVP` model
-    action: torch.Tensor
-        column of actions S(\phi) for set of sample states
+    target_log_density: torch.Tensor
+        column of log(p) for a sample of states, which includes the negative action
+        -S(\phi) and a possible contribution for the volume element due to a
+        non-trivial parameterisation.
 
     Returns
     -------
@@ -29,11 +33,12 @@ def shifted_kl(model_log_density: torch.Tensor, action: torch.Tensor) -> torch.T
         shifted K-L for set of sample states.
 
     """
-    return torch.mean(model_log_density + action, dim=0)
+    return torch.mean(model_log_density - target_log_density, dim=0)
 
 
 def train(
     loaded_model,
+    generator,
     action,
     *,
     train_range,
@@ -51,7 +56,7 @@ def train(
     )
     # let's use tqdm to see progress
     pbar = tqdm(range(*train_range), desc=f"loss: {current_loss}")
-    n_units = loaded_model.size_in
+    n_units = generator.size_out
     for i in pbar:
         if (i % save_interval) == 0:
             torch.save(
@@ -64,12 +69,14 @@ def train(
                 f"{outpath}/checkpoint_{i}.pt",
             )
         # gen simple states
-        z = loaded_model.generator(n_batch)
-        phi, model_log_density = loaded_model(z)
-        target = action(phi)
+        z, base_log_density = generator(n_batch)
+        phi, map_log_density = loaded_model(z)
+
+        model_log_density = base_log_density + map_log_density
+        target_log_density = -action(phi)  # term from parameterisatiom goes here
 
         loaded_model.zero_grad()  # get rid of stored gradients
-        current_loss = shifted_kl(model_log_density, target)
+        current_loss = shifted_kl(model_log_density, target_log_density)
         current_loss.backward()  # calc gradients
 
         loaded_optimizer.step()

--- a/anvil/train.py
+++ b/anvil/train.py
@@ -10,13 +10,13 @@ import torch
 import torch.optim as optim
 
 
-def shifted_kl(log_tilde_p: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+def shifted_kl(model_log_density: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
     r"""Sample mean of the shifted Kullbach-Leibler divergence between target
     and model distribution.
 
     Parameters
     ----------
-    log_tilde_p: torch.Tensor
+    model_log_density: torch.Tensor
         column of log (\tilde p) for a sample of states, which is returned by
         forward pass of `RealNVP` model
     action: torch.Tensor
@@ -29,7 +29,7 @@ def shifted_kl(log_tilde_p: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
         shifted K-L for set of sample states.
 
     """
-    return torch.mean(log_tilde_p + action, dim=0)
+    return torch.mean(model_log_density + action, dim=0)
 
 
 def train(
@@ -65,12 +65,11 @@ def train(
             )
         # gen simple states
         z = loaded_model.generator(n_batch)
-        phi, output = loaded_model(z)
+        phi, model_log_density = loaded_model(z)
         target = action(phi)
-        #output = loaded_model(phi)
 
         loaded_model.zero_grad()  # get rid of stored gradients
-        current_loss = shifted_kl(output, target)
+        current_loss = shifted_kl(model_log_density, target)
         current_loss.backward()  # calc gradients
 
         loaded_optimizer.step()

--- a/anvil/train.py
+++ b/anvil/train.py
@@ -65,9 +65,9 @@ def train(
             )
         # gen simple states
         z = loaded_model.generator(n_batch)
-        phi = loaded_model.inverse_map(z)
+        phi, output = loaded_model(z)
         target = action(phi)
-        output = loaded_model(phi)
+        #output = loaded_model(phi)
 
         loaded_model.zero_grad()  # get rid of stored gradients
         current_loss = shifted_kl(output, target)

--- a/anvil/train.py
+++ b/anvil/train.py
@@ -73,7 +73,7 @@ def train(
         phi, map_log_density = loaded_model(z)
 
         model_log_density = base_log_density + map_log_density
-        target_log_density = target.log_density(phi)  # term from parameterisatiom goes here
+        target_log_density = target(phi)  # term from parameterisatiom goes here
 
         loaded_model.zero_grad()  # get rid of stored gradients
         current_loss = shifted_kl(model_log_density, target_log_density)

--- a/examples/runcards/phi4_train.yml
+++ b/examples/runcards/phi4_train.yml
@@ -2,10 +2,11 @@
 lattice_length: 6
 lattice_dimension: 2
 
-# Action
-m_sq: 4
-lam: 0
-use_arxiv_version: True
+theory: "phi_four"
+theory_parameters:
+    m_sq: 4
+    lam: 0
+    use_arxiv_version: False
 
 # Networks
 hidden_nodes: [24]
@@ -13,7 +14,7 @@ n_affine: 2
 n_batch: 2000
 
 # Training length
-epochs: 1000
+epochs: 5000
 save_interval: 1000
 
 # Optimizer ('adam', 'adadelta')

--- a/examples/runcards/phi4_train.yml
+++ b/examples/runcards/phi4_train.yml
@@ -3,10 +3,10 @@ lattice_length: 6
 lattice_dimension: 2
 
 theory: "phi_four"
-theory_parameters:
-    m_sq: 4
-    lam: 0
-    use_arxiv_version: False
+
+m_sq: 4
+lam: 0
+use_arxiv_version: False
 
 # Networks
 hidden_nodes: [24]


### PR DESCRIPTION
The O(N) non-linear sigma is basically ready for a PR. However, I've been struggling to find a satisfactory way of introducing the flexibility to specify the target distribution (action, parameterisation) and flow model (RealNVP + many others to come) in the runcard.

It may be that I have missed some key feature of reportengine's Config class, but it seems to me that it might not be designed for this level of flexibility - e.g. different actions with completely different parameters. You can do this with dictionaries but then you avoid all the features of the config parser and have to manually check that the dict has valid keys and values..

This PR currently doesn't do too much, but I thought it better to start a discussion sooner rather than later because I've already spent a fair amount of time struggling to come up with something decent.

Basically, what would be really useful going forward would be the ability to specify
- base distribution
- theory (action) + parameterisation -> target distribution
- flow model (which could be much more flexible than it is now)

in the runcard.

One idea, not implemented yet, could be to have a module `options` which contains dictionaries of the form `theories = {"phi_four": PhiFourAction}` which could be imported by `config.py`, so that string parameters from the runcard could be used to index a dict, the result which would be returned by a `produce` function. That would mean we could simplify our "manual" checks by just checking that the string input is a dictionary key.

Please let me know what you think. I think that getting this sorted will mean I can go ahead and introduce different actions, flow models etc. with much greater ease.