### PR TITLE
Training against simple distributions

### DIFF
--- a/anvil/checkpoint.py
+++ b/anvil/checkpoint.py
@@ -6,13 +6,6 @@ we don't get unexpected results
 """
 from copy import deepcopy
 
-import torch.optim as optim
-
-valid_optimizers = {
-    "adam": optim.Adam,
-    "adadelta": optim.Adadelta,
-}
-
 
 def loaded_checkpoint(checkpoint):
     if checkpoint is None:
@@ -35,17 +28,6 @@ def loaded_model(loaded_checkpoint, model):
     if loaded_checkpoint is not None:
         new_model.load_state_dict(loaded_checkpoint["model_state_dict"])
     return new_model
-
-
-def loaded_optimizer(
-    loaded_model, loaded_checkpoint, optimizer="adam", optimizer_kwargs={}
-):
-    new_optimizer = valid_optimizers[optimizer](
-        loaded_model.parameters(), **optimizer_kwargs
-    )
-    if loaded_checkpoint is not None:
-        new_optimizer.load_state_dict(loaded_checkpoint["optimizer_state_dict"])
-    return new_optimizer
 
 
 def current_loss(loaded_checkpoint):

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -9,33 +9,12 @@ from reportengine.report import Config
 from reportengine.configparser import ConfigError, element_of, explicit_node
 
 from anvil.core import TrainingOutput
-from anvil.train import (
-    adam,
-    adadelta,
-    stochastic_gradient_descent,
-    reduce_lr_on_plateau,
-)
+from anvil.train import OPTIMIZER_OPTIONS, reduce_lr_on_plateau
 from anvil.models import RealNVP
 from anvil.geometry import Geometry2D
-from anvil.distributions import *
+from anvil.distributions import BASE_OPTIONS, TARGET_OPTIONS
 
 log = logging.getLogger(__name__)
-
-BASE_OPTIONS = {
-    "standard_normal": standard_normal_distribution,
-    "normal": normal_distribution,
-    "uniform": uniform_distribution,
-    "circular_uniform": circular_uniform_distribution,
-    "von_mises": von_mises_distribution,
-    "spherical_uniform": spherical_uniform_distribution,
-}
-TARGET_OPTIONS = dict({"phi_four": phi_four_action,}, **BASE_OPTIONS)
-
-OPTIMIZER_OPTIONS = {
-    "adam": adam,
-    "adadelta": adadelta,
-    "sgd": stochastic_gradient_descent,
-}
 
 
 class ConfigParser(Config):

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -9,7 +9,12 @@ from reportengine.report import Config
 from reportengine.configparser import ConfigError, element_of, explicit_node
 
 from anvil.core import TrainingOutput
-from anvil.train import adam, adadelta, stochastic_gradient_descent, reduce_lr_on_plateau
+from anvil.train import (
+    adam,
+    adadelta,
+    stochastic_gradient_descent,
+    reduce_lr_on_plateau,
+)
 from anvil.models import RealNVP
 from anvil.geometry import Geometry2D
 from anvil.distributions import *
@@ -163,11 +168,6 @@ class ConfigParser(Config):
     @explicit_node
     def produce_scheduler(self):
         return reduce_lr_on_plateau
-
-    def parse_scheduler_kwargs(self, kwargs: dict):
-        if "patience" not in kwargs:
-            kwargs["patience"] = 500  # problem setting default in config parser?
-        return kwargs
 
     def parse_target_length(self, targ: int):
         return targ

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -47,6 +47,18 @@ class ConfigParser(Config):
     def parse_base(self, base: str):
         return base
 
+    def parse_mean(self, mean: (float, int)):
+        return mean
+
+    def parse_sigma(self, sigma: (float, int)):
+        return sigma
+
+    def parse_support(self, supp: list):
+        return supp
+
+    def parse_concentration(self, conc: float):
+        return conc
+
     def parse_m_sq(self, m: (float, int)):
         return m
 

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -21,6 +21,7 @@ BASE_OPTIONS = {
     "normal": normal_distribution,
     "uniform": uniform_distribution,
     "circular_uniform": circular_uniform_distribution,
+    "von_mises": von_mises_distribution,
     "spherical_uniform": spherical_uniform_distribution,
 }
 TARGET_OPTIONS = dict({"phi_four": phi_four_action,}, **BASE_OPTIONS)

--- a/anvil/config.py
+++ b/anvil/config.py
@@ -174,10 +174,10 @@ class ConfigParser(Config):
         return interval
 
     def parse_n_boot(self, n_boot: int):
-        if n_samples < 2:
+        if n_boot < 2:
             raise ConfigError("n_boot must be greater than 1")
-        log.warning(f"Using user specified n_boot: {n_samples}")
-        return n_samples
+        log.warning(f"Using user specified n_boot: {n_boot}")
+        return n_boot
 
     @element_of("windows")
     def parse_window(self, window: float):

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -450,3 +450,21 @@ def xy_hamiltonian(beta, geometry):
 
 def heisenberg_hamiltonian(beta, geometry):
     return HeisenbergHamiltonian(beta, geometry)
+
+
+BASE_OPTIONS = {
+    "standard_normal": standard_normal_distribution,
+    "normal": normal_distribution,
+    "uniform": uniform_distribution,
+    "circular_uniform": circular_uniform_distribution,
+    "von_mises": von_mises_distribution,
+    "spherical_uniform": spherical_uniform_distribution,
+}
+TARGET_OPTIONS = dict(
+    {
+        "phi_four": phi_four_action,
+        "xy": xy_hamiltonian,
+        "heisenberg": heisenberg_hamiltonian,
+    },
+    **BASE_OPTIONS
+)

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -219,7 +219,7 @@ class SphericalUniformDist:
 def standard_normal_distribution(config_size):
     """returns an instance of the NormalDist class with mean 0 and
     variance 1"""
-    return NormalDist(config_size)
+    return NormalDist(config_size, scale=1, loc=0)
 
 
 def normal_distribution(config_size, scale=1, loc=0):
@@ -305,6 +305,8 @@ class PhiFourAction(nn.Module):
         else:
             self.version_factor = 1
 
+        self.log_density = self.forward
+
     def forward(self, phi_state: torch.Tensor) -> torch.Tensor:
         """Perform forward pass, returning -action for stack of states. Note
         here the minus sign since we want to return the log density of the
@@ -324,9 +326,6 @@ class PhiFourAction(nn.Module):
             dim=1, keepdim=True  # sum across sites
         )
         return -action
-
-    def log_density(phi_state):
-        return self.forward(phi_state)
 
 
 class XYHamiltonian(nn.Module):
@@ -352,6 +351,8 @@ class XYHamiltonian(nn.Module):
         self.beta = beta
         self.lattice_size = geometry.length ** 2
         self.shift = geometry.get_shift()
+
+        self.log_density = self.forward
 
     def forward(self, state: torch.Tensor) -> torch.Tensor:
         """
@@ -392,6 +393,8 @@ class HeisenbergHamiltonian(nn.Module):
         self.beta = beta
         self.lattice_size = geometry.length ** 2
         self.shift = geometry.get_shift()
+
+        self.log_density = self.forward
 
     def forward(self, state: torch.Tensor) -> torch.Tensor:
         r"""

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -46,7 +46,9 @@ class NormalDist:
         Return shape: (sample_size, lattice_size) for the sample,
         (sample_size, 1) for the log density.
         """
-        sample = torch.randn(sample_size, self.size_out)
+        sample = torch.empty(sample_size, self.size_out).normal_(
+            mean=self.mean, std=self.sigma
+        )
 
         return sample, self.log_density(sample)
 
@@ -73,7 +75,6 @@ class UniformDist:
         self.size_out = lattice_size
 
         self.x_min, self.x_max = support
-        self.x_range = self.x_max - self.x_min
 
         self.log_density = lambda sample: torch.zeros((sample.size[0], 1))
 
@@ -84,7 +85,9 @@ class UniformDist:
         Return shape: (sample_size, lattice_size) for the sample,
         (sample_size, 1) for the log density.
         """
-        sample = torch.rand(sample_size, self.size_out) * self.x_range - self.x_max
+        sample = torch.empty(sample_size, self.size_out).uniform_(
+            self.x_min, self.x_max
+        )
         return sample, torch.zeros((sample_size, 1))
 
 

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -254,10 +254,10 @@ def spherical_uniform_distribution(lattice_size):
     return SphericalUniformDist(lattice_size)
 
 
-class PhiFourAction(nn.Module):
-    """Extend the nn.Module class to return the phi^4 action given either
-    a single state size (1, length * length) or a stack of N states
-    (N, length * length). See Notes about action definition.
+class PhiFourAction:
+    """Return the phi^4 action given either a single state size
+    (1, length * length) or a stack of N states (N, length * length).
+    See Notes about action definition.
 
     The forward pass returns the corresponding log density (unnormalised) which
     is equal to -S
@@ -308,9 +308,7 @@ class PhiFourAction(nn.Module):
         else:
             self.version_factor = 1
 
-        self.log_density = self.forward
-
-    def forward(self, phi_state: torch.Tensor) -> torch.Tensor:
+    def log_density(self, phi_state: torch.Tensor) -> torch.Tensor:
         """Perform forward pass, returning -action for stack of states. Note
         here the minus sign since we want to return the log density of the
         corresponding unnormalised distribution
@@ -331,14 +329,16 @@ class PhiFourAction(nn.Module):
         return -action
 
 
-class XYHamiltonian(nn.Module):
-    """
-    Extend the nn.Module class to return the Hamiltonian for the classical
-    XY spin model (also known as the O(2) model), given a stack of polar
-    angles with shape (sample_size, lattice_size).
+class O2Action:
+    r"""
+    The (shifted) action for the O(2) non-linear sigma model, calculated
+    from a stack of polar angles with shape (sample_size, lattice_size).
+    
+    The action is shifted by -2 * V * \beta, making it equivalent to \beta
+    times the Hamiltonian for the classical XY spin model.
 
-    The spins are defined as having modulus 1, such that they take values
-    on the unit circle.
+    The fields or 'spins' are defined as having modulus 1, such that they
+    take values on the unit circle.
 
     Parameters
     ----------
@@ -355,31 +355,32 @@ class XYHamiltonian(nn.Module):
         self.lattice_size = geometry.length ** 2
         self.shift = geometry.get_shift()
 
-        self.log_density = self.forward
-
-    def forward(self, state: torch.Tensor) -> torch.Tensor:
+    def log_density(self, state: torch.Tensor) -> torch.Tensor:
         """
-        Compute XY Hamiltonian from a stack of angles (not Euclidean field components)
+        Compute action from a stack of angles (not Euclidean field components)
         with shape (sample_size, lattice_size).
         """
-        hamiltonian = -self.beta * torch.cos(
+        action = -self.beta * torch.cos(
             state[:, self.shift] - state.view(-1, 1, self.lattice_size)
         ).sum(
             dim=1,
         ).sum(  # sum over two shift directions (+ve nearest neighbours)
             dim=1, keepdim=True
         )  # sum over lattice sites
-        return -hamiltonian
+        return -action
 
 
-class HeisenbergHamiltonian(nn.Module):
-    """
-    Extend the nn.Module class to return the Hamiltonian for the classical
-    Heisenberg model (also known as the O(3) model), given a stack of polar
-    angles with shape (sample_size, 2 * lattice_size).
+class O3Action:
+    r"""
+    The (shifted) action for the O(3) non-linear sigma model, calculated from
+    a stack of polar and azimuthal angles with shape
+    (sample_size, 2 * lattice_size).
 
-    The spins are defined as having modulus 1, such that they take values
-    on the unit 2-sphere, and can be parameterised by two angles using
+    The action is shifted by -2 * V * \beta, making it equivalent to \beta
+    times the Hamiltonian for the classical Heisenberg spin model.
+
+    The field or 'spins' are defined as having modulus 1, such that they take
+    values on the unit 2-sphere, and can be parameterised by two angles using
     spherical polar coordinates (with the radial coordinate equal to one).
 
     Parameters
@@ -397,11 +398,9 @@ class HeisenbergHamiltonian(nn.Module):
         self.lattice_size = geometry.length ** 2
         self.shift = geometry.get_shift()
 
-        self.log_density = self.forward
-
-    def forward(self, state: torch.Tensor) -> torch.Tensor:
+    def log_density(self, state: torch.Tensor) -> torch.Tensor:
         r"""
-        Compute classical Heisenberg Hamiltonian from a stack of angles with shape
+        Compute the O(3) action from a stack of angles with shape
         (sample_size, 2 * volume).
 
         Also computes the logarithm of the 'volume element' for the probability
@@ -424,7 +423,7 @@ class HeisenbergHamiltonian(nn.Module):
         cos_polar = torch.cos(polar)
         sin_polar = torch.sin(polar)
 
-        hamiltonian = -self.beta * (
+        action = -self.beta * (
             cos_polar[:, self.shift] * cos_polar.view(-1, 1, self.lattice_size)
             + sin_polar[:, self.shift]
             * sin_polar.view(-1, 1, self.lattice_size)
@@ -437,7 +436,7 @@ class HeisenbergHamiltonian(nn.Module):
 
         log_volume_element = torch.log(sin_polar).sum(dim=1, keepdim=True)
 
-        return log_volume_element - hamiltonian
+        return log_volume_element - action
 
 
 def phi_four_action(m_sq, lam, geometry, use_arxiv_version):
@@ -447,12 +446,12 @@ def phi_four_action(m_sq, lam, geometry, use_arxiv_version):
     )
 
 
-def xy_hamiltonian(beta, geometry):
-    return XYHamiltonian(beta, geometry)
+def o2_action(beta, geometry):
+    return O2Action(beta, geometry)
 
 
-def heisenberg_hamiltonian(beta, geometry):
-    return HeisenbergHamiltonian(beta, geometry)
+def o3_action(beta, geometry):
+    return O3Action(beta, geometry)
 
 
 BASE_OPTIONS = {
@@ -464,10 +463,5 @@ BASE_OPTIONS = {
     "spherical_uniform": spherical_uniform_distribution,
 }
 TARGET_OPTIONS = dict(
-    {
-        "phi_four": phi_four_action,
-        "xy": xy_hamiltonian,
-        "heisenberg": heisenberg_hamiltonian,
-    },
-    **BASE_OPTIONS
+    {"phi_four": phi_four_action, "o2": o2_action, "o3": o3_action,}, **BASE_OPTIONS
 )

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -125,9 +125,9 @@ class VonMisesDist:
         self.generator = torch.distributions.von_mises.VonMises(
             loc=loc, concentration=concentration
         ).sample
-        
+
     def __call__(self, sample_size):
-        sample = self.generator(sample_size)
+        sample = self.generator((sample_size, self.size_out))
         log_density = self.log_density(sample)
         return sample, log_density
 
@@ -280,11 +280,10 @@ class PhiFourAction(nn.Module):
 
     def __init__(self, m_sq, lam, geometry, use_arxiv_version=False):
         super(PhiFourAction, self).__init__()
-        self.geometry = geometry
-        self.shift = self.geometry.get_shift()
+        self.shift = geometry.get_shift()
         self.lam = lam
         self.m_sq = m_sq
-        self.length = self.geometry.length
+        self.lattice_size = geometry.length ** 2
         if use_arxiv_version:
             self.version_factor = 2
         else:
@@ -302,7 +301,7 @@ class PhiFourAction(nn.Module):
             + self.lam * phi_state ** 4  # phi^4 term
             - self.version_factor
             * torch.sum(
-                phi_state[:, self.shift] * phi_state.view(-1, 1, self.length ** 2),
+                phi_state[:, self.shift] * phi_state.view(-1, 1, self.lattice_size),
                 dim=1,
             )  # derivative
         ).sum(
@@ -314,8 +313,121 @@ class PhiFourAction(nn.Module):
         return self.forward(phi_state)
 
 
+class XYHamiltonian(nn.Module):
+    """
+    Extend the nn.Module class to return the Hamiltonian for the classical
+    XY spin model (also known as the O(2) model), given a stack of polar
+    angles with shape (sample_size, lattice_size).
+
+    The spins are defined as having modulus 1, such that they take values
+    on the unit circle.
+
+    Parameters
+    ----------
+    geometry:
+        define the geometry of the lattice, including dimension, size and
+        how the state is split into two parts
+    beta: float
+        the inverse temperature (coupling strength).
+    """
+
+    def __init__(self, beta, geometry):
+        super().__init__()
+        self.beta = beta
+        self.lattice_size = geometry.length ** 2
+        self.shift = geometry.get_shift()
+
+    def forward(self, state: torch.Tensor) -> torch.Tensor:
+        """
+        Compute XY Hamiltonian from a stack of angles (not Euclidean field components)
+        with shape (sample_size, lattice_size).
+        """
+        hamiltonian = -self.beta * torch.cos(
+            state[:, self.shift] - state.view(-1, 1, self.lattice_size)
+        ).sum(
+            dim=1,
+        ).sum(  # sum over two shift directions (+ve nearest neighbours)
+            dim=1, keepdim=True
+        )  # sum over lattice sites
+        return -hamiltonian
+
+
+class HeisenbergHamiltonian(nn.Module):
+    """
+    Extend the nn.Module class to return the Hamiltonian for the classical
+    Heisenberg model (also known as the O(3) model), given a stack of polar
+    angles with shape (sample_size, 2 * lattice_size).
+
+    The spins are defined as having modulus 1, such that they take values
+    on the unit 2-sphere, and can be parameterised by two angles using
+    spherical polar coordinates (with the radial coordinate equal to one).
+
+    Parameters
+    ----------
+    geometry:
+        define the geometry of the lattice, including dimension, size and
+        how the state is split into two parts
+    beta: float
+        the inverse temperature (coupling strength).
+    """
+
+    def __init__(self, beta, geometry):
+        super().__init__()
+        self.beta = beta
+        self.lattice_size = geometry.length ** 2
+        self.shift = geometry.get_shift()
+
+    def forward(self, state: torch.Tensor) -> torch.Tensor:
+        r"""
+        Compute classical Heisenberg Hamiltonian from a stack of angles with shape
+        (sample_size, 2 * volume).
+
+        Also computes the logarithm of the 'volume element' for the probability
+        distribution due to parameterisating the spin vectors using polar coordinates.
+        
+        The volume element for a configuration is a product over all lattice sites
+        
+            \prod_{n=1}^V sin(\theta_n)
+
+        where \theta_n is the polar angle for the spin at site n.
+        
+        Notes
+        -----
+        Assumes that state.view(-1, lattice_size, 2) yields a tensor for which the
+        two elements in the final dimension represent, respectively, the polar and
+        azimuthal angles for the same lattice site.
+        """
+        polar = state[:, ::2]
+        azimuth = state[:, 1::2]
+        cos_polar = torch.cos(polar)
+        sin_polar = torch.sin(polar)
+
+        hamiltonian = -self.beta * (
+            cos_polar[:, self.shift] * cos_polar.view(-1, 1, self.lattice_size)
+            + sin_polar[:, self.shift]
+            * sin_polar.view(-1, 1, self.lattice_size)
+            * torch.cos(azimuth[:, self.shift] - azimuth.view(-1, 1, self.lattice_size))
+        ).sum(
+            dim=1,
+        ).sum(  # sum over two shift directions (+ve nearest neighbours)
+            dim=1, keepdim=True
+        )  # sum over lattice sites
+
+        log_volume_element = torch.log(sin_polar).sum(dim=1, keepdim=True)
+
+        return log_volume_element - hamiltonian
+
+
 def phi_four_action(m_sq, lam, geometry, use_arxiv_version):
     """returns instance of PhiFourAction"""
     return PhiFourAction(
         m_sq, lam, geometry=geometry, use_arxiv_version=use_arxiv_version
     )
+
+
+def xy_hamiltonian(beta, geometry):
+    return XYHamiltonian(beta, geometry)
+
+
+def heisenberg_hamiltonian(beta, geometry):
+    return HeisenbergHamiltonian(beta, geometry)

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -102,8 +102,8 @@ class AffineLayer(nn.Module):
                 for t_in, t_out in zip(t_shape[:-2], t_shape[1:-1])
             ]
         )
-        # No ReLU on final layers: need to be able to scale data by
-        # 0 < s, not 1 < s, and enact both +/- shifts
+        # By default not activation function on final layer
+        # TODO: REALLY need flexibility to specify this in the runcard
         self.s_layers += [nn.Linear(s_shape[-2], s_shape[-1])]
         self.t_layers += [nn.Linear(t_shape[-2], t_shape[-1])]
 

--- a/anvil/sample.py
+++ b/anvil/sample.py
@@ -15,7 +15,6 @@ from reportengine import collect
 
 log = logging.getLogger(__name__)
 
-import numpy as np
 
 class LogRatioNanError(Exception):
     pass
@@ -65,9 +64,6 @@ def sample_batch(
     with torch.no_grad():  # don't track gradients
         z, base_log_density = base_dist(batch_size + 1)
         phi, map_log_density = loaded_model(z)  # map using trained loaded_model to phi
-
-        np.savetxt("base.txt", z)
-        np.savetxt("target.txt", phi)
 
         model_log_density = base_log_density + map_log_density
 

--- a/anvil/sample.py
+++ b/anvil/sample.py
@@ -15,6 +15,7 @@ from reportengine import collect
 
 log = logging.getLogger(__name__)
 
+import numpy as np
 
 class LogRatioNanError(Exception):
     pass
@@ -64,6 +65,10 @@ def sample_batch(
     with torch.no_grad():  # don't track gradients
         z, base_log_density = base_dist(batch_size + 1)
         phi, map_log_density = loaded_model(z)  # map using trained loaded_model to phi
+
+        np.savetxt("base.txt", z)
+        np.savetxt("target.txt", phi)
+
         model_log_density = base_log_density + map_log_density
 
         if current_state is not None:

--- a/anvil/sample.py
+++ b/anvil/sample.py
@@ -13,8 +13,6 @@ from tqdm import tqdm
 
 from reportengine import collect
 
-import numpy as np
-
 log = logging.getLogger(__name__)
 
 
@@ -64,10 +62,6 @@ def sample_batch(
     with torch.no_grad():  # don't track gradients
         z, base_log_density = base_dist(batch_size + 1)
         phi, map_log_density = loaded_model(z)  # map using trained loaded_model to phi
-        if not phi.requires_grad:
-            np.savetxt("base.txt", z)
-            np.savetxt("target.txt", phi)
-
         model_log_density = base_log_density + map_log_density
 
         if current_state is not None:

--- a/anvil/train.py
+++ b/anvil/train.py
@@ -94,6 +94,7 @@ def train(
 def adam(
     loaded_model,
     loaded_checkpoint,
+    *,
     lr=0.001,
     betas=(0.9, 0.999),
     eps=1e-08,
@@ -114,7 +115,7 @@ def adam(
 
 
 def adadelta(
-    loaded_model, loaded_checkpoint, lr=1.0, rho=0.9, eps=1e-06, weight_decay=0
+    loaded_model, loaded_checkpoint, *, lr=1.0, rho=0.9, eps=1e-06, weight_decay=0
 ):
     optimizer = optim.Adadelta(
         loaded_model.parameters(), lr=lr, rho=rho, eps=eps, weight_decay=weight_decay
@@ -127,6 +128,7 @@ def adadelta(
 def stochastic_gradient_descent(
     loaded_model,
     loaded_checkpoint,
+    *,
     lr,
     momentum=0,
     dampening=0,
@@ -146,12 +148,38 @@ def stochastic_gradient_descent(
     return optimizer
 
 
+def rms_prop(
+    loaded_model,
+    loaded_checkpoint,
+    *,
+    lr=0.01,
+    alpha=0.99,
+    eps=1e-08,
+    weight_decay=0,
+    momentum=0,
+    centered=False,
+):
+    optimizer = optim.RMSprop(
+        loaded_model.parameters(),
+        lr=lr,
+        alpha=alpha,
+        eps=eps,
+        weight_decay=weight_decay,
+        momentum=momentum,
+        centered=centered,
+    )
+    if loaded_checkpoint is not None:
+        optimizer.load_state_dict(loaded_checkpoint["optimizer_state_dict"])
+    return optimizer
+
+
 def reduce_lr_on_plateau(
     loaded_optimizer,
+    *,
     mode="min",
     factor=0.1,
-    patience=500,
-    verbose=True,
+    patience=500,  # not the PyTorch default
+    verbose=False,
     threshold=0.0001,
     threshold_mode="rel",
     cooldown=0,
@@ -170,3 +198,11 @@ def reduce_lr_on_plateau(
         min_lr=min_lr,
         eps=eps,
     )
+
+
+OPTIMIZER_OPTIONS = {
+    "adam": adam,
+    "adadelta": adadelta,
+    "sgd": stochastic_gradient_descent,
+    "rms_prop": rms_prop,
+}

--- a/anvil/train.py
+++ b/anvil/train.py
@@ -95,19 +95,19 @@ def adam(
     loaded_model,
     loaded_checkpoint,
     *,
-    lr=0.001,
-    betas=(0.9, 0.999),
-    eps=1e-08,
-    weight_decay=0,
-    amsgrad=False,
+    learning_rate=0.001,
+    adam_betas=(0.9, 0.999),
+    optimizer_stability_factor=1e-08,
+    optimizer_weight_decay=0,
+    adam_use_amsgrad=False,
 ):
     optimizer = optim.Adam(
         loaded_model.parameters(),
-        lr=lr,
-        betas=betas,
-        eps=eps,
-        weight_decay=weight_decay,
-        amsgrad=amsgrad,
+        lr=learning_rate,
+        betas=adam_betas,
+        eps=optimizer_stability_factor,
+        weight_decay=optimizer_weight_decay,
+        amsgrad=adam_use_amsgrad,
     )
     if loaded_checkpoint is not None:
         optimizer.load_state_dict(loaded_checkpoint["optimizer_state_dict"])
@@ -115,10 +115,20 @@ def adam(
 
 
 def adadelta(
-    loaded_model, loaded_checkpoint, *, lr=1.0, rho=0.9, eps=1e-06, weight_decay=0
+    loaded_model,
+    loaded_checkpoint,
+    *,
+    learning_rate=1.0,
+    adadelta_rho=0.9,
+    optimizer_stability_factor=1e-06,
+    optimizer_weight_decay=0,
 ):
     optimizer = optim.Adadelta(
-        loaded_model.parameters(), lr=lr, rho=rho, eps=eps, weight_decay=weight_decay
+        loaded_model.parameters(),
+        lr=learning_rate,
+        rho=adadelta_rho,
+        eps=optimizer_stability_factor,
+        weight_decay=optimizer_weight_decay,
     )
     if loaded_checkpoint is not None:
         optimizer.load_state_dict(loaded_checkpoint["optimizer_state_dict"])
@@ -129,19 +139,19 @@ def stochastic_gradient_descent(
     loaded_model,
     loaded_checkpoint,
     *,
-    lr,
-    momentum=0,
-    dampening=0,
-    weight_decay=0,
-    nesterov=False,
+    learning_rate,
+    sgd_momentum=0,
+    sgd_dampening=0,
+    optimizer_weight_decay=0,
+    sgd_use_nesterov=False,
 ):
     optimizer = optim.SGD(
         loaded_model.parameters(),
-        lr=lr,
-        momentum=momentum,
-        dampening=dampening,
-        weight_decay=weight_decay,
-        nesterov=nesterov,
+        lr=learning_rate,
+        momentum=optimizer_momentum,
+        dampening=optimizer_dampening,
+        weight_decay=optimizer_weight_decay,
+        nesterov=sgd_use_nesterov,
     )
     if loaded_checkpoint is not None:
         optimizer.load_state_dict(loaded_checkpoint["optimizer_state_dict"])
@@ -152,21 +162,21 @@ def rms_prop(
     loaded_model,
     loaded_checkpoint,
     *,
-    lr=0.01,
-    alpha=0.99,
-    eps=1e-08,
-    weight_decay=0,
-    momentum=0,
-    centered=False,
+    learning_rate=0.01,
+    rmsprop_smoothing=0.99,
+    optimizer_stability_factor=1e-08,
+    optimizer_weight_decay=0,
+    optimizer_momentum=0,
+    rmsprop_use_centered=False,
 ):
     optimizer = optim.RMSprop(
         loaded_model.parameters(),
-        lr=lr,
-        alpha=alpha,
-        eps=eps,
-        weight_decay=weight_decay,
-        momentum=momentum,
-        centered=centered,
+        lr=learning_Rate,
+        alpha=rmsprop_smoothing,
+        eps=optimizer_stability_factor,
+        weight_decay=optimizer_weight_decay,
+        momentum=optimizer_momentum,
+        centered=rmsprop_use_centered,
     )
     if loaded_checkpoint is not None:
         optimizer.load_state_dict(loaded_checkpoint["optimizer_state_dict"])
@@ -176,27 +186,25 @@ def rms_prop(
 def reduce_lr_on_plateau(
     loaded_optimizer,
     *,
-    mode="min",
-    factor=0.1,
+    lr_reduction_factor=0.1,
+    min_learning_rate=0,
     patience=500,  # not the PyTorch default
-    verbose=False,
-    threshold=0.0001,
-    threshold_mode="rel",
     cooldown=0,
-    min_lr=0,
-    eps=1e-08,
+    verbose_scheduler=False,
+    scheduler_threshold=0.0001,
+    scheduler_threshold_mode="rel",
+    scheduler_stability_factor=1e-08,
 ):
     return optim.lr_scheduler.ReduceLROnPlateau(
         loaded_optimizer,
-        mode=mode,
-        factor=factor,
+        factor=lr_reduction_factor,
         patience=patience,
-        verbose=verbose,
-        threshold=threshold,
-        threshold_mode=threshold_mode,
+        verbose=verbose_scheduler,
+        threshold=scheduler_threshold,
+        threshold_mode=scheduler_threshold_mode,
         cooldown=cooldown,
-        min_lr=min_lr,
-        eps=eps,
+        min_lr=min_learning_rate,
+        eps=scheduler_stability_factor,
     )
 
 

--- a/anvil/train.py
+++ b/anvil/train.py
@@ -140,8 +140,8 @@ def stochastic_gradient_descent(
     loaded_checkpoint,
     *,
     learning_rate,
-    sgd_momentum=0,
-    sgd_dampening=0,
+    optimizer_momentum=0,
+    optimizer_dampening=0,
     optimizer_weight_decay=0,
     sgd_use_nesterov=False,
 ):

--- a/examples/runcards/phi4_sample.yml
+++ b/examples/runcards/phi4_sample.yml
@@ -1,4 +1,4 @@
-training_output: phi4_train
+training_output: train
 
 cp_id: -1
 target_length: 10000

--- a/examples/runcards/phi4_train.yml
+++ b/examples/runcards/phi4_train.yml
@@ -22,7 +22,8 @@ save_interval: 1000
 
 # Optimizer
 optimizer: 'adam'
-lr: 0.01
+learning_rate: 0.001
 
 # Scheduler
-factor: 0.5
+verbose_scheduler: true
+lr_reduction_factor: 0.5

--- a/examples/runcards/phi4_train.yml
+++ b/examples/runcards/phi4_train.yml
@@ -2,28 +2,27 @@
 lattice_length: 6
 lattice_dimension: 2
 
-theory: "phi_four"
-
+# Target
+target: "phi_four"
 m_sq: 4
 lam: 0
 use_arxiv_version: False
 
+# Base
+base: "standard_normal"
+
 # Networks
 hidden_nodes: [24]
-n_affine: 2
-n_batch: 2000
+n_affine: 4
+n_batch: 1000
 
 # Training length
-epochs: 5000
+epochs: 3000
 save_interval: 1000
 
-# Optimizer ('adam', 'adadelta')
+# Optimizer
 optimizer: 'adam'
-optimizer_kwargs:
-    lr: 0.01
+lr: 0.01
 
 # Scheduler
-scheduler_kwargs:
-    verbose: true
-    factor: 0.5
-    patience: 500
+factor: 0.5


### PR DESCRIPTION
### TL;DR: Sometimes you just want to see if a model can map a Gaussian to another Gaussian.

It's useful to be able to train models to learn simple target distributions with parameters which are easy to tune (rather than e.g. turning the quartic term off in the phi^4 theory to get a Gaussian target, or using the spin models at high temperature to get a uniform target).

We can use the same distribution classes, but it means that, while base distributions are generally used via the `__call__` method, which returns a sample and its log density, target distributions end up being used via the `log_density` method, to avoid unnecessarily generating samples each time.

I've added another action `standard_normal_distribution` alongside `normal_distribution` (which can have any mean or variance), so different Gaussians can be used as the base and the target. I think generally the reportengine dependency graph prevents using the same distribution for base and target with different parameters, without having a separate action for each. That's not a big deal though.

### Optimizer and scheduler

I've also committed further abuses with `@explicit_node`, this time with the optimizer, so that now all of the kwargs are directly accessible from the runcard. It also made setting defaults much simpler and more transparent.

I have checked to make sure that it works correctly when restarting from a checkpoint.

I realise that it made some sense to have the `loaded_optimizer` action where it was, with the other checkpoint stuff. I tried out a few other ways of organising this which kept that action, but I think this way works best, from the options I could think of.

### Issues

- Some lack of consistency regarding whether `lattice_size` or `config_size` or `geometry.length ** 2` are used for the size of the second dimension of tensors. Not urgent but it's in the back of my mind. Only really matters if we want to include a second e.g. gauge field, or go to d > 2.
- It may not be sensible to have lots of optimizer and scheduler parameters with short labels such as `lr` and `eps` (and `betas`!) given in the runcard as they are. I guess this increases the chance of an accidental name clash. They could all be given names such as `optim_lr`, `optim_eps` etc.

### Some context:
This has already thrown up some very useful results! For example, when trying to learn a Gaussian target, you can see Adam run into its "overshoot" problem as you increase the target variance, since the gradient of the "potential well" becomes too small to counter the momentum in the optimizer.