### PR TITLE
New coupling layer: "non-compact projection"

### DIFF
--- a/anvil/layers.py
+++ b/anvil/layers.py
@@ -229,19 +229,18 @@ class NCPLayer(CouplingLayer):
         *,
         hidden_shape: list,
         activation: str,
+        s_final_activation: str,
         batch_normalise: bool,
-        i_layer: int,
         even_sites: bool,
     ):
-        super().__init__(size_half, i_layer, even_sites)
+        super().__init__(size_half, even_sites)
         self.s_network = NeuralNetwork(
             size_in=size_half,
             size_out=size_half,
             hidden_shape=hidden_shape,
             activation=activation,
-            final_activation=None,
+            final_activation=s_final_activation,
             batch_normalise=batch_normalise,
-            label=f"({self.label}) 's' network",
         )
         self.t_network = NeuralNetwork(
             size_in=size_half,
@@ -250,7 +249,6 @@ class NCPLayer(CouplingLayer):
             activation=activation,
             final_activation=None,
             batch_normalise=batch_normalise,
-            label=f"({self.label}) 't' network",
         )
         self.phase_shift = nn.Parameter(torch.rand(1))
 
@@ -334,7 +332,7 @@ class InverseProjectionLayer(nn.Module):
 
     def forward(self, x_input, log_density):
         """Forward pass of the inverse projection transformation."""
-        phi_out = (2 * torch.atan(x_input) + pi)
+        phi_out = 2 * torch.atan(x_input) + pi
         log_density -= 2 * torch.log(torch.cos(0.5 * (phi_out - pi))).sum(
             dim=1, keepdim=True
         )

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -64,8 +64,22 @@ def real_nvp_sphere(size_half, real_nvp):
         layers.InverseProjectionLayer2D(size_half),
     )
 
-def ncp_circle(config_size):
-    return layers.NCPLayer(size_in=config_size)
+
+def ncp_circle(
+    size_half, hidden_shape=[24,], activation="leaky_relu", batch_normalise=False
+):
+    """Action that returns a callable object that performs a transformation from
+    (0, 2\pi) -> (0, 2\pi) that is the composition of a stereographic projection
+    transformation, an affine transformation, and the inverse projection."""
+    return coupling_pair(
+        layers.NCPLayer,
+        size_half,
+        hidden_shape=hidden_shape,
+        activation=activation,
+        batch_normalise=batch_normalise,
+        i_layer=0,  # currently composition of these layers isn't supported (use real_nvp_circle)
+    )
+
 
 MODEL_OPTIONS = {
     "real_nvp": real_nvp,

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -64,9 +64,12 @@ def real_nvp_sphere(size_half, real_nvp):
         layers.InverseProjectionLayer2D(size_half),
     )
 
+def ncp_circle(config_size):
+    return layers.NCPLayer(size_in=config_size)
 
 MODEL_OPTIONS = {
     "real_nvp": real_nvp,
     "real_nvp_circle": real_nvp_circle,
     "real_nvp_sphere": real_nvp_sphere,
+    "ncp_circle": ncp_circle,
 }

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -90,31 +90,6 @@ def ncp_circle(
     return Sequential(*ncp_pairs)
 
 
-def ncp_circle(
-    size_half,
-    n_layers=1,  # unlikely that function composition is beneficial
-    hidden_shape=[24,],
-    activation="leaky_relu",
-    s_final_activation=None,
-    batch_normalise=False,
-):
-    """Action that returns a callable object that performs a sequence of transformations
-    from (0, 2\pi) -> (0, 2\pi), each of which are the composition of a stereographic
-    projection transformation, an affine transformation, and the inverse projection."""
-    ncp_pairs = [
-        coupling_pair(
-            layers.NCPLayer,
-            size_half,
-            hidden_shape=hidden_shape,
-            activation=activation,
-            s_final_activation=s_final_activation,
-            batch_normalise=batch_normalise,
-        )
-        for _ in range(n_layers)
-    ]
-    return Sequential(*ncp_pairs)
-
-
 MODEL_OPTIONS = {
     "real_nvp": real_nvp,
     "real_nvp_circle": real_nvp_circle,

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -66,19 +66,53 @@ def real_nvp_sphere(size_half, real_nvp):
 
 
 def ncp_circle(
-    size_half, hidden_shape=[24,], activation="leaky_relu", batch_normalise=False
+    size_half,
+    n_layers=1,  # unlikely that function composition is beneficial
+    hidden_shape=[24,],
+    activation="leaky_relu",
+    s_final_activation=None,
+    batch_normalise=False,
 ):
-    """Action that returns a callable object that performs a transformation from
-    (0, 2\pi) -> (0, 2\pi) that is the composition of a stereographic projection
-    transformation, an affine transformation, and the inverse projection."""
-    return coupling_pair(
-        layers.NCPLayer,
-        size_half,
-        hidden_shape=hidden_shape,
-        activation=activation,
-        batch_normalise=batch_normalise,
-        i_layer=0,  # currently composition of these layers isn't supported (use real_nvp_circle)
-    )
+    """Action that returns a callable object that performs a sequence of transformations
+    from (0, 2\pi) -> (0, 2\pi), each of which are the composition of a stereographic
+    projection transformation, an affine transformation, and the inverse projection."""
+    ncp_pairs = [
+        coupling_pair(
+            layers.NCPLayer,
+            size_half,
+            hidden_shape=hidden_shape,
+            activation=activation,
+            s_final_activation=s_final_activation,
+            batch_normalise=batch_normalise,
+        )
+        for _ in range(n_layers)
+    ]
+    return Sequential(*ncp_pairs)
+
+
+def ncp_circle(
+    size_half,
+    n_layers=1,  # unlikely that function composition is beneficial
+    hidden_shape=[24,],
+    activation="leaky_relu",
+    s_final_activation=None,
+    batch_normalise=False,
+):
+    """Action that returns a callable object that performs a sequence of transformations
+    from (0, 2\pi) -> (0, 2\pi), each of which are the composition of a stereographic
+    projection transformation, an affine transformation, and the inverse projection."""
+    ncp_pairs = [
+        coupling_pair(
+            layers.NCPLayer,
+            size_half,
+            hidden_shape=hidden_shape,
+            activation=activation,
+            s_final_activation=s_final_activation,
+            batch_normalise=batch_normalise,
+        )
+        for _ in range(n_layers)
+    ]
+    return Sequential(*ncp_pairs)
 
 
 MODEL_OPTIONS = {

--- a/examples/runcards/ncp_circle.yml
+++ b/examples/runcards/ncp_circle.yml
@@ -1,0 +1,27 @@
+# Lattice
+lattice_length: 6
+lattice_dimension: 2
+
+# Target
+target: von_mises
+concentration: 0.9
+mean: 2.0
+
+# Model
+base: circular_uniform
+model: ncp_circle
+model_spec: [{}]
+n_mixture: 4
+
+# Training
+n_batch: 1000
+epochs: 3000
+save_interval: 1000
+
+# Optimizer
+optimizer: adam
+learning_rate: 0.001
+
+# Scheduler
+verbose_scheduler: true
+lr_reduction_factor: 0.5

--- a/examples/runcards/ncp_circle.yml
+++ b/examples/runcards/ncp_circle.yml
@@ -4,14 +4,16 @@ lattice_dimension: 2
 
 # Target
 target: von_mises
-concentration: 0.9
+concentration: 0.6
 mean: 2.0
 
 # Model
 base: circular_uniform
 model: ncp_circle
-model_spec: [{}]
-n_mixture: 4
+model_spec:
+    hidden_shape: [24]    
+
+n_mixture: 1
 
 # Training
 n_batch: 1000


### PR DESCRIPTION
An alternative to wrapping Real NVP in projection and inverse projection maps. Instead, each coupling layer is a composition of a projection, a single affine transformation, and an inverse projection.

This is implemented as described in section 2.1.3 of https://arxiv.org/pdf/2002.02428.pdf. However, I haven't linearised the transformation close to 0 and 2pi, since so far all attempts have been computationally expensive and haven't noticeable improved the training.