### PR TITLE
New coupling layer: linear spline

### DIFF
--- a/anvil/config.py
+++ b/anvil/config.py
@@ -82,10 +82,6 @@ class ConfigParser(Config):
         """Standard deviation of normal distribution."""
         return sigma
 
-    def parse_support(self, supp: list):
-        """Support of uniform distrbution."""
-        return supp
-
     def parse_concentration(self, conc: float):
         """Concentration parameter of von Mises distribution."""
         return conc

--- a/anvil/core.py
+++ b/anvil/core.py
@@ -142,6 +142,12 @@ class ConvexCombination(nn.Module):
         Returns the convex combination of probability densities output by the flow
         replica, along with the convex combination of logarithms of probability 
         densities.
+
+    Notes
+    -----
+    It is assumed that the log_density input to the forward method is the logarithm
+    of a *normalised* probability density - i.e. the base log density is normalised and
+    we don't neglect additive constants to the log density during the flow.
     """
 
     def __init__(self, flow_replica):
@@ -179,7 +185,7 @@ class ConvexCombination(nn.Module):
 
             phi_flow, log_dens_flow = flow(input_copy, zero_density)
             phi_out += weight * phi_flow
-            density += weight * torch.exp(log_dens_flow)# / (2 * pi)  # needs to be log of normalised pdf!
+            density += weight * torch.exp(log_dens_flow)
 
         return phi_out, log_density_base + torch.log(density)
 

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -88,7 +88,10 @@ class UniformDist:
 
         self.x_min, self.x_max = support
 
-        self.log_density = lambda sample: torch.zeros((sample.shape[0], 1))
+        self._log_density = -log((self.x_max - self.x_min) * lattice_size)  # normalised
+        self.log_density = (
+            lambda sample: torch.ones((sample.shape[0], 1)) * self._log_density
+        )
 
     def __call__(self, sample_size):
         """Return a tuple (sample, log_density) for a sample of 'sample_size'
@@ -100,13 +103,12 @@ class UniformDist:
         sample = torch.empty(sample_size, self.size_out).uniform_(
             self.x_min, self.x_max
         )
-        return sample, torch.zeros((sample_size, 1))
+        return sample, self.log_density(sample)
 
     @property
     def pdf(self):
         x = torch.linspace(self.x_min, self.x_max, 10000)
-        dens = 1 / (self.x_max - self.x_min)
-        return ((x, torch.zeros_like(x) + dens),)
+        return ((x, torch.zeros_like(x) + 1 / (self.x_max - self.x_min)),)
 
 
 class SemicircleDist:

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -86,6 +86,7 @@ class UniformDist:
     def __init__(self, lattice_size, *, support):
         self.size_out = lattice_size
 
+        self.support = support
         self.x_min, self.x_max = support
 
         self.log_normalisation = log(self.x_max - self.x_min)
@@ -129,6 +130,7 @@ class SemicircleDist:
         self.size_out = lattice_size
         self.radius = radius
         self.mean = mean
+        self.support = (mean - radius, mean + radius)
 
         self.log_normalisation = self.size_out * log((pi * self.radius ** 2) / 2)
 
@@ -199,6 +201,8 @@ class VonMisesDist:
     the log density calculation. There's no good reason for this other
     than it's nice to see the calculation written out.
     """
+
+    support = (0, 2 * pi)
 
     def __init__(self, lattice_size, *, concentration, mean):
         self.size_out = lattice_size
@@ -447,6 +451,7 @@ class O2Action:
     beta: float
         the inverse temperature (coupling strength).
     """
+    support = (0, 2 * pi)
 
     def __init__(self, beta, geometry):
         super().__init__()

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -88,9 +88,9 @@ class UniformDist:
 
         self.x_min, self.x_max = support
 
-        self._log_density = -log((self.x_max - self.x_min) * lattice_size)  # normalised
+        self.log_normalisation = log(self.x_max - self.x_min)
         self.log_density = (
-            lambda sample: torch.ones((sample.shape[0], 1)) * self._log_density
+            lambda sample: torch.zeros((sample.shape[0], 1)) - self.log_normalisation
         )
 
     def __call__(self, sample_size):

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -86,6 +86,7 @@ class UniformDist:
     def __init__(self, lattice_size, *, support):
         self.size_out = lattice_size
 
+        self.support = support
         self.x_min, self.x_max = support
 
         self.log_density = lambda sample: torch.zeros((sample.shape[0], 1))
@@ -127,6 +128,7 @@ class SemicircleDist:
         self.size_out = lattice_size
         self.radius = radius
         self.mean = mean
+        self.support = (mean - radius, mean + radius)
 
         self.log_normalisation = self.size_out * log((pi * self.radius ** 2) / 2)
 
@@ -197,6 +199,8 @@ class VonMisesDist:
     the log density calculation. There's no good reason for this other
     than it's nice to see the calculation written out.
     """
+
+    support = (0, 2 * pi)
 
     def __init__(self, lattice_size, *, concentration, mean):
         self.size_out = lattice_size
@@ -445,6 +449,7 @@ class O2Action:
     beta: float
         the inverse temperature (coupling strength).
     """
+    support = (0, 2 * pi)
 
     def __init__(self, beta, geometry):
         super().__init__()

--- a/anvil/layers.py
+++ b/anvil/layers.py
@@ -447,3 +447,32 @@ class InverseProjectionLayer2D(nn.Module):
         ).sum(dim=1)
 
         return phi_out.view(-1, self.size_out), log_density
+
+
+class GlobalAffineLayer(nn.Module):
+    r"""Applies an affine transformation to every data point using a given scale and shift,
+    which are *not* learnable. Useful to shift the domain of a learned distribution. This is
+    done at the cost of a constant term in the logarithm of the Jacobian determinant, which
+    is ignored.
+
+    Parameters
+    ----------
+    scale: (int, float)
+        Every data point will be multiplied by this factor.
+    shift: (int, float)
+        Every scaled data point will be shifted by this factor.
+
+    Methods
+    -------
+    forward(x_input, log_density)
+        see docstring for anvil.layers
+    """
+
+    def __init__(self, scale, shift):
+        super().__init__()
+        self.scale = scale
+        self.shift = shift
+
+    def forward(self, x_input, log_density):
+        """Forward pass of the global affine transformation."""
+        return self.scale * x_input + self.shift, log_density

--- a/anvil/layers.py
+++ b/anvil/layers.py
@@ -38,17 +38,6 @@ from math import pi
 
 from anvil.core import NeuralNetwork
 
-def get_segment(data, knot_points):
-    """Given a batch of input vectors with dimensions (n_batch, D) and knot points
-    (bin edges) with dimensions (n_batch, D, n_segments + 1) return a tensor corresponding
-    to the segments (bins) in which each data point lies, dimensions (n_batch, D, 1)."""
-    with torch.no_grad():
-        data.unsqueeze_(dim=-1)
-        indices = torch.empty_like(data, dtype=torch.long)
-        for i in range(data.shape[0]):
-            indices[i] = searchsorted(knot_points[i], data[i]) - 1
-        indices[indices < 0] = 0
-        return indices
 
 class CouplingLayer(nn.Module):
     """
@@ -193,7 +182,6 @@ class AffineLayer(CouplingLayer):
 
 
 class LinearSplineLayer(CouplingLayer):
-<<<<<<< HEAD
     r"""A coupling transformation from [0, 1] -> [0, 1] based on a piecewise linear function.
 
     The interval is divided into K equal-width (w) segments (bins), with K+1 knot points
@@ -261,7 +249,7 @@ class LinearSplineLayer(CouplingLayer):
 
         eps = 1e-6  # prevent rounding error which causes sorting into -1th bin
         self.x_knot_points = torch.linspace(-eps, 1 + eps, n_segments + 1).view(1, -1)
-        
+
         self.h_network = NeuralNetwork(
             size_in=size_half,
             size_out=size_half * n_segments,

--- a/anvil/layers.py
+++ b/anvil/layers.py
@@ -258,10 +258,6 @@ class LinearSplineLayer(CouplingLayer):
             final_activation=activation,
             batch_normalise=batch_normalise,
         )
-<<<<<<< HEAD
-=======
-
->>>>>>> b410f114699103bf09ba65e74864d0e8f34a482d
         self.norm_func = nn.Softmax(dim=2)
 
     def forward(self, x_input, log_density):
@@ -288,7 +284,7 @@ class LinearSplineLayer(CouplingLayer):
         p_k = torch.gather(net_out, 2, k_ind)
         alpha = (x_b.unsqueeze(dim=-1) - k_ind * self.width) / self.width
         phi_km1 = torch.gather(phi_knot_points, 2, k_ind)
-        
+
         phi_b = (phi_km1 + alpha * p_k).squeeze()
         phi_out = self._join_func([x_a, phi_b], dim=1)
         log_density -= torch.log(p_k).sum(dim=1)

--- a/anvil/layers.py
+++ b/anvil/layers.py
@@ -287,7 +287,7 @@ class LinearSplineLayer(CouplingLayer):
         
         phi_b = (phi_km1 + alpha * p_k).squeeze()
         phi_out = self._join_func([x_a, phi_b], dim=1)
-        log_density -= torch.log(h_k).sum(dim=1)
+        log_density -= torch.log(p_k).sum(dim=1)
 
         return phi_out, log_density
 

--- a/anvil/layers.py
+++ b/anvil/layers.py
@@ -46,8 +46,9 @@ def get_segment(data, knot_points):
         data.unsqueeze_(dim=-1)
         indices = torch.empty_like(data, dtype=torch.long)
         for i in range(data.shape[0]):
-            indices[i] = searchsorted(knot_points[i], data[i])
-        return indices - 1
+            indices[i] = searchsorted(knot_points[i], data[i]) - 1
+        indices[indices < 0] = 0
+        return indices
 
 class CouplingLayer(nn.Module):
     """
@@ -199,10 +200,9 @@ class LinearSplineLayer(CouplingLayer):
         hidden_shape: list,
         activation: str,
         batch_normalise: bool,
-        i_layer: int,
         even_sites: bool,
     ):
-        super().__init__(size_half, i_layer, even_sites)
+        super().__init__(size_half, even_sites)
 
         self.size_half = size_half
         self.n_segments = n_segments
@@ -216,7 +216,6 @@ class LinearSplineLayer(CouplingLayer):
             activation=activation,
             final_activation=activation,
             batch_normalise=batch_normalise,
-            label=f"{self.label}",
         )
 
         self.norm_func = nn.Softmax(dim=2)

--- a/anvil/layers.py
+++ b/anvil/layers.py
@@ -278,12 +278,9 @@ class LinearSplineLayer(CouplingLayer):
             dim=2,
         )
 
-        # NOTE: This is *essential*, otherwise searchsorted gives nonsense results for
-        # all but the first row. I don't understand why!
-        x_to_sort = x_b.clone().detach()
-
         # Sort x_b into the appropriate bin
-        k_ind = searchsorted(self.x_knot_points, x_to_sort) - 1
+        # NOTE: need to make x_b contiguous, otherwise searchsorted returns nonsense
+        k_ind = searchsorted(self.x_knot_points, x_b.contiguous()) - 1
         k_ind.unsqueeze_(dim=-1)
 
         h_k = torch.gather(net_out, 2, k_ind)

--- a/anvil/layers.py
+++ b/anvil/layers.py
@@ -46,8 +46,9 @@ def get_segment(data, knot_points):
         data.unsqueeze_(dim=-1)
         indices = torch.empty_like(data, dtype=torch.long)
         for i in range(data.shape[0]):
-            indices[i] = searchsorted(knot_points[i], data[i])
-        return indices - 1
+            indices[i] = searchsorted(knot_points[i], data[i]) - 1
+        indices[indices < 0] = 0
+        return indices
 
 class CouplingLayer(nn.Module):
     """

--- a/anvil/layers.py
+++ b/anvil/layers.py
@@ -38,6 +38,16 @@ from math import pi
 
 from anvil.core import NeuralNetwork
 
+def get_segment(data, knot_points):
+    """Given a batch of input vectors with dimensions (n_batch, D) and knot points
+    (bin edges) with dimensions (n_batch, D, n_segments + 1) return a tensor corresponding
+    to the segments (bins) in which each data point lies, dimensions (n_batch, D, 1)."""
+    with torch.no_grad():
+        data.unsqueeze_(dim=-1)
+        indices = torch.empty_like(data, dtype=torch.long)
+        for i in range(data.shape[0]):
+            indices[i] = searchsorted(knot_points[i], data[i])
+        return indices - 1
 
 class CouplingLayer(nn.Module):
     """
@@ -182,6 +192,7 @@ class AffineLayer(CouplingLayer):
 
 
 class LinearSplineLayer(CouplingLayer):
+<<<<<<< HEAD
     r"""A coupling transformation from [0, 1] -> [0, 1] based on a piecewise linear function.
 
     The interval is divided into K equal-width (w) segments (bins), with K+1 knot points
@@ -243,14 +254,13 @@ class LinearSplineLayer(CouplingLayer):
         even_sites: bool,
     ):
         super().__init__(size_half, even_sites)
-
         self.size_half = size_half
         self.n_segments = n_segments
         self.width = 1 / n_segments
 
         eps = 1e-6  # prevent rounding error which causes sorting into -1th bin
         self.x_knot_points = torch.linspace(-eps, 1 + eps, n_segments + 1).view(1, -1)
-
+        
         self.h_network = NeuralNetwork(
             size_in=size_half,
             size_out=size_half * n_segments,

--- a/anvil/layers.py
+++ b/anvil/layers.py
@@ -194,14 +194,14 @@ class LinearSplineLayer(CouplingLayer):
 
     The inverse coupling transformation is
 
-        \phi = C^{-1}(x, {h_k}) = \phi_{k-1} + \alpha h_k
+        \phi = C^{-1}(x, {p_k}) = \phi_{k-1} + \alpha p_k
 
-    where x_{k-1} = \sum_{k'=1}^{k-1} h_{k'} is the (k-1)-th knot point, and \alpha is the
+    where \phi_{k-1} = \sum_{k'=1}^{k-1} p_{k'} is the (k-1)-th knot point, and \alpha is the
     fractional position of x in the k-th bin, which is (x - (k-1) * w) / w.
 
     The gradient of the forward transformation is simply
         
-        dx / d\phi = w / h_k
+        dx / d\phi = w / p_k
 
     Parameters
     ----------
@@ -243,7 +243,6 @@ class LinearSplineLayer(CouplingLayer):
         even_sites: bool,
     ):
         super().__init__(size_half, even_sites)
-
         self.size_half = size_half
         self.n_segments = n_segments
         self.width = 1 / n_segments
@@ -251,7 +250,7 @@ class LinearSplineLayer(CouplingLayer):
         eps = 1e-6  # prevent rounding error which causes sorting into -1th bin
         self.x_knot_points = torch.linspace(-eps, 1 + eps, n_segments + 1).view(1, -1)
 
-        self.h_network = NeuralNetwork(
+        self.network = NeuralNetwork(
             size_in=size_half,
             size_out=size_half * n_segments,
             hidden_shape=hidden_shape,
@@ -259,7 +258,6 @@ class LinearSplineLayer(CouplingLayer):
             final_activation=activation,
             batch_normalise=batch_normalise,
         )
-
         self.norm_func = nn.Softmax(dim=2)
 
     def forward(self, x_input, log_density):
@@ -268,7 +266,7 @@ class LinearSplineLayer(CouplingLayer):
         x_b = x_input[:, self._b_ind]
 
         net_out = self.norm_func(
-            self.h_network(x_a - 0.5).view(-1, self.size_half, self.n_segments)
+            self.network(x_a - 0.5).view(-1, self.size_half, self.n_segments)
         )
         phi_knot_points = torch.cat(
             (
@@ -283,11 +281,11 @@ class LinearSplineLayer(CouplingLayer):
         k_ind = searchsorted(self.x_knot_points, x_b.contiguous()) - 1
         k_ind.unsqueeze_(dim=-1)
 
-        h_k = torch.gather(net_out, 2, k_ind)
-        phi_km1 = torch.gather(phi_knot_points, 2, k_ind)
+        p_k = torch.gather(net_out, 2, k_ind)
         alpha = (x_b.unsqueeze(dim=-1) - k_ind * self.width) / self.width
-        phi_b = (phi_km1 + alpha * h_k).squeeze()
-
+        phi_km1 = torch.gather(phi_knot_points, 2, k_ind)
+        
+        phi_b = (phi_km1 + alpha * p_k).squeeze()
         phi_out = self._join_func([x_a, phi_b], dim=1)
         log_density -= torch.log(h_k).sum(dim=1)
 

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -81,7 +81,6 @@ def linear_spline(
         hidden_shape=hidden_shape,
         activation=activation,
         batch_normalise=batch_normalise,
-        i_layer=0,
     )
 
 

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -10,10 +10,12 @@ from anvil.core import Sequential
 
 import anvil.layers as layers
 
+
 def support(target_dist):
     """Return the support of the target distribution."""
     # NOTE: may need to rethink this for multivariate distributions
     return target_dist.support
+
 
 def coupling_pair(coupling_layer, size_half, **layer_spec):
     """Helper function which returns a callable object that performs a coupling
@@ -89,13 +91,6 @@ def linear_spline(
             batch_normalise=batch_normalise,
         ),
         layers.GlobalAffineLayer(scale=support[1] - support[0], shift=support[0]),
-    return coupling_pair(
-        layers.LinearSplineLayer,
-        size_half,
-        n_segments=n_segments,
-        hidden_shape=hidden_shape,
-        activation=activation,
-        batch_normalise=batch_normalise,
     )
 
 

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -65,8 +65,29 @@ def real_nvp_sphere(size_half, real_nvp):
     )
 
 
+def linear_spline(
+    size_half,
+    n_segments=4,
+    hidden_shape=[24,],
+    activation="leaky_relu",
+    batch_normalise=False,
+):
+    """Action that returns a callable object that performs a pair of linear spline
+    transformations, one on each half of the input vector."""
+    return coupling_pair(
+        layers.LinearSplineLayer,
+        size_half,
+        n_segments=n_segments,
+        hidden_shape=hidden_shape,
+        activation=activation,
+        batch_normalise=batch_normalise,
+        i_layer=0,
+    )
+
+
 MODEL_OPTIONS = {
     "real_nvp": real_nvp,
     "real_nvp_circle": real_nvp_circle,
     "real_nvp_sphere": real_nvp_sphere,
+    "linear_spline": linear_spline,
 }

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -96,7 +96,6 @@ def linear_spline(
         hidden_shape=hidden_shape,
         activation=activation,
         batch_normalise=batch_normalise,
-        i_layer=0,
     )
 
 

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -10,10 +10,6 @@ from anvil.core import Sequential
 
 import anvil.layers as layers
 
-def support(target_dist):
-    """Return the support of the target distribution."""
-    # NOTE: may need to rethink this for multivariate distributions
-    return target_dist.support
 
 def support(target_dist):
     """Return the support of the target distribution."""

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -10,6 +10,10 @@ from anvil.core import Sequential
 
 import anvil.layers as layers
 
+def support(target_dist):
+    """Return the support of the target distribution."""
+    # NOTE: may need to rethink this for multivariate distributions
+    return target_dist.support
 
 def coupling_pair(coupling_layer, size_half, **layer_spec):
     """Helper function which returns a callable object that performs a coupling
@@ -67,6 +71,7 @@ def real_nvp_sphere(size_half, real_nvp):
 
 def linear_spline(
     size_half,
+    support=(0, 1),
     n_segments=4,
     hidden_shape=[24,],
     activation="leaky_relu",
@@ -74,13 +79,16 @@ def linear_spline(
 ):
     """Action that returns a callable object that performs a pair of linear spline
     transformations, one on each half of the input vector."""
-    return coupling_pair(
-        layers.LinearSplineLayer,
-        size_half,
-        n_segments=n_segments,
-        hidden_shape=hidden_shape,
-        activation=activation,
-        batch_normalise=batch_normalise,
+    return Sequential(
+        coupling_pair(
+            layers.LinearSplineLayer,
+            size_half,
+            n_segments=n_segments,
+            hidden_shape=hidden_shape,
+            activation=activation,
+            batch_normalise=batch_normalise,
+        ),
+        layers.GlobalAffineLayer(scale=support[1] - support[0], shift=support[0]),
     )
 
 

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -89,6 +89,14 @@ def linear_spline(
             batch_normalise=batch_normalise,
         ),
         layers.GlobalAffineLayer(scale=support[1] - support[0], shift=support[0]),
+    return coupling_pair(
+        layers.LinearSplineLayer,
+        size_half,
+        n_segments=n_segments,
+        hidden_shape=hidden_shape,
+        activation=activation,
+        batch_normalise=batch_normalise,
+        i_layer=0,
     )
 
 


### PR DESCRIPTION
This is the simplest coupling layer based on a 'spline', which maps [0, 1] -> [0, 1]. Introduced in https://arxiv.org/pdf/1808.03856.pdf.

We use a neural network to output a set of probability masses for bins of width 1 / N_bins, and use the cumulative distribution function as our coupling transformation (since it's monotonic).

It uses a third-party package called [torchsearchsorted](https://github.com/aliutkus/torchsearchsorted) to sort the x_input into the correct bin.
This has a potential advantage over the numpy versionhttps://github.com/aliutkus/torchsearchsorted in that, if the bin boundaries vary within the batch, it can still sort the entire batch in one go.
This isn't needed in the linear case but it is in #49.

---

If we wanted to improve performance we could, in future, try the "one blob encoding" discussed in the same paper, which involves replacing a single 'x' with a Gaussian that activates several bins at once.