### PR TITLE
Spline flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ conda install -c conda-forge tqdm
 conda install scipy
 ```
 
+To use `spline' flows, the third-party package *torchsearchsorted* must be installed.
+Download the source from the [github repo](https://github.com/aliutkus/torchsearchsorted) and, with the conda environment activated, run
+```bash
+pip install .
+```
+in the root folder.
+
 These are the minimal requirements for running the code, however if you plan
 on developing the code or doing small external tests, then I highly recommend also
 installing the following packages

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -85,7 +85,7 @@ class UniformDist:
 
     def __init__(self, lattice_size, *, support):
         self.size_out = lattice_size
-
+        self.support = support
         self.x_min, self.x_max = support
 
         self.log_normalisation = log(self.x_max - self.x_min)
@@ -129,6 +129,7 @@ class SemicircleDist:
         self.size_out = lattice_size
         self.radius = radius
         self.mean = mean
+        self.support = (mean - radius, mean + radius)
 
         self.log_normalisation = self.size_out * log((pi * self.radius ** 2) / 2)
 
@@ -199,6 +200,7 @@ class VonMisesDist:
     the log density calculation. There's no good reason for this other
     than it's nice to see the calculation written out.
     """
+    support = (0, 2 * pi)
 
     def __init__(self, lattice_size, *, concentration, mean):
         self.size_out = lattice_size
@@ -447,6 +449,7 @@ class O2Action:
     beta: float
         the inverse temperature (coupling strength).
     """
+    support = (0, 2 * pi)
 
     def __init__(self, beta, geometry):
         super().__init__()

--- a/anvil/layers.py
+++ b/anvil/layers.py
@@ -292,6 +292,147 @@ class LinearSplineLayer(CouplingLayer):
         return phi_out, log_density
 
 
+class QuadraticSplineLayer(CouplingLayer):
+    r"""A coupling transformation from [0, 1] -> [0, 1] based on a piecewise quadratic function.
+
+    The interval is divided into K segments (bins), with K+1 knot points (bin boundaries).
+    The coupling transformation is defined piecewise by the unique polynomials whose
+    end-points are the knot points.
+
+    A neural network generates K+1 values for the y-positions (heights) at the x knot points,
+    and K bin widths. The inverse coupling transformation is then defined as the cumulative
+    distribution function associated with the piecewise linear probability density function
+    obtained by interpolating between the heights.
+
+    The result is a quadratic function defined piecewise by 
+
+        \phi = C^{-1}(x, {h_k}) = \phi_{k-1} + \alpha(x) h_k w_k
+                                  + \alpha(x)^2 / 2 * (h_{k+1} - h_k) w_k
+
+    where \alpha(x) is the fractional position within a bin,
+
+        \alpha(x) = (x - x_{k-1}) / w_k
+
+    Parameters
+    ----------
+    size_half: int
+        Half of the configuration size, which is the size of the input vector for the
+        neural network.
+    hidden_shape: list
+        list containing hidden vector sizes the neural network.
+    activation: str
+        string which is a key for an activation function for all but the final layers
+        of the network.
+    batch_normalise: bool
+        flag indicating whether or not to use batch normalising within the neural
+        network.
+    even_sites: bool
+        dictates which half of the data is transformed as a and b, since successive
+        affine transformations alternate which half of the data is passed through
+        neural network.
+
+    Attributes
+    ----------
+    h_network: torch.nn.Module
+        the dense layers of network h, values are intialised as per the default
+        initialisation of `nn.Linear`
+
+    Methods
+    -------
+    forward(x_input, log_density)
+        see docstring for anvil.layers
+    """
+
+    def __init__(
+        self,
+        size_half: int,
+        n_segments: int,
+        hidden_shape: list,
+        activation: str,
+        batch_normalise: bool,
+        even_sites: bool,
+    ):
+        super().__init__(size_half, even_sites)
+        self.size_half = size_half
+        self.n_segments = n_segments
+
+        self.network = NeuralNetwork(
+            size_in=size_half,
+            size_out=size_half * (2 * n_segments + 1),
+            hidden_shape=hidden_shape,
+            activation=activation,
+            final_activation=activation,
+            batch_normalise=batch_normalise,
+        )
+        self.w_norm_func = nn.Softmax(dim=2)
+
+        self.eps = 1e-6  # prevent rounding error which causes sorting into -1th bin
+
+    @staticmethod
+    def h_norm_func(h_raw, w_norm):
+        """Normalisation function for height values."""
+        return torch.exp(h_raw) / (
+            0.5 * w_norm * (torch.exp(h_raw[..., :-1]) + torch.exp(h_raw[..., 1:]))
+        ).sum(dim=2, keepdim=True)
+
+    def forward(self, x_input, log_density):
+        """Forward pass of the quadratic spline layer."""
+        x_a = x_input[:, self._a_ind]
+        x_b = x_input[:, self._b_ind]
+
+        h_raw, w_raw = (
+            self.network(x_a - 0.5)
+            .view(-1, self.size_half, 2 * self.n_segments + 1)
+            .split((self.n_segments + 1, self.n_segments), dim=2)
+        )
+        w_norm = self.w_norm_func(w_raw)
+        h_norm = self.h_norm_func(h_raw, w_norm)
+
+        x_knot_points = torch.cat(
+            (
+                torch.zeros(h_norm.shape[0], self.size_half, 1) - self.eps,
+                torch.cumsum(w_norm, dim=2),
+            ),
+            dim=2,
+        )
+        phi_knot_points = torch.cat(
+            (
+                torch.zeros(h_norm.shape[0], self.size_half, 1),
+                torch.cumsum(
+                    0.5 * w_norm * (h_norm[..., :-1] + h_norm[..., 1:]), dim=2,
+                ),
+            ),
+            dim=2,
+        )
+
+        # Temporarily mix batch and lattice dimensions so that the bisection search
+        # can be done in a single operation
+        k_ind = (
+            searchsorted(
+                x_knot_points.contiguous().view(-1, self.n_segments + 1),
+                x_b.contiguous().view(-1, 1),
+            )
+            - 1
+        ).view(-1, self.size_half, 1)
+
+        w_k = torch.gather(w_norm, 2, k_ind)
+        h_k = torch.gather(h_norm, 2, k_ind)
+        h_kp1 = torch.gather(h_norm, 2, k_ind + 1)
+
+        x_km1 = torch.gather(x_knot_points, 2, k_ind)
+        phi_km1 = torch.gather(phi_knot_points, 2, k_ind)
+
+        alpha = (x_b.unsqueeze(dim=-1) - x_km1) / w_k
+        phi_b = (
+            phi_km1 + alpha * h_k * w_k + 0.5 * alpha.pow(2) * (h_kp1 - h_k) * w_k
+        ).squeeze()
+
+        phi_out = self._join_func([x_a, phi_b], dim=1)
+        log_density -= torch.log(h_k + alpha * (h_kp1 - h_k)).sum(dim=1)
+
+        return phi_out, log_density
+
+
 class ProjectionLayer(nn.Module):
     r"""Applies the stereographic projection map S1 - {0} -> R1 to the entire
     input vector.

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -121,10 +121,30 @@ def quadratic_spline(
     )
 
 
+def circular_spline(
+    size_half,
+    n_segments=4,
+    hidden_shape=[24,],
+    activation="leaky_relu",
+    batch_normalise=False,
+):
+    """Action that returns a callable object that performs a pair of circular spline
+    transformations, one on each half of the input vector."""
+    return coupling_pair(
+        layers.CircularSplineLayer,
+        size_half,
+        n_segments=n_segments,
+        hidden_shape=hidden_shape,
+        activation=activation,
+        batch_normalise=batch_normalise,
+    )
+
+
 MODEL_OPTIONS = {
     "real_nvp": real_nvp,
     "real_nvp_circle": real_nvp_circle,
     "real_nvp_sphere": real_nvp_sphere,
     "linear_spline": linear_spline,
     "quadratic_spline": quadratic_spline,
+    "circular_spline": circular_spline,
 }

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -96,9 +96,35 @@ def linear_spline(
     )
 
 
+def quadratic_spline(
+    size_half,
+    target_support,
+    n_segments=4,
+    hidden_shape=[24,],
+    activation="leaky_relu",
+    batch_normalise=False,
+):
+    """Action that returns a callable object that performs a pair of linear spline
+    transformations, one on each half of the input vector."""
+    return Sequential(
+        coupling_pair(
+            layers.QuadraticSplineLayer,
+            size_half,
+            n_segments=n_segments,
+            hidden_shape=hidden_shape,
+            activation=activation,
+            batch_normalise=batch_normalise,
+        ),
+        layers.GlobalAffineLayer(
+            scale=target_support[1] - target_support[0], shift=target_support[0]
+        ),
+    )
+
+
 MODEL_OPTIONS = {
     "real_nvp": real_nvp,
     "real_nvp_circle": real_nvp_circle,
     "real_nvp_sphere": real_nvp_sphere,
     "linear_spline": linear_spline,
+    "quadratic_spline": quadratic_spline,
 }

--- a/examples/runcards/spline.yml
+++ b/examples/runcards/spline.yml
@@ -1,0 +1,30 @@
+# Lattice
+lattice_length: 2
+lattice_dimension: 2
+
+# Target
+target: von_mises
+concentration: 0.5
+mean: 1.06
+
+# Model
+base: circular_uniform
+model: circular_spline
+model_spec:
+    n_segments: 16
+    hidden_shape: [64]
+n_mixture: 1
+
+# Training
+n_batch: 1000
+epochs: 3000
+save_interval: 1000
+
+# Optimizer
+optimizer: adam
+learning_rate: 0.001
+
+# Scheduler
+verbose_scheduler: true
+lr_reduction_factor: 0.5
+


### PR DESCRIPTION
A single branch / PR for all three implemented 'spline' flows, containing three new coupling layers

1. Linear spline: [0, 1] -> [0, 1], introduced in https://arxiv.org/pdf/1808.03856.pdf.
2. Quadratic spline: same as above.
3. Circular spline: S1 -> S1, based on the "monotonic rational quadratic transform introduced in https://arxiv.org/pdf/1906.04032.pdf, but where the boundary conditions are such that the transformation maps 1-dimensional directional data, as proposed in https://arxiv.org/pdf/2002.02428.pdf (2.1.2).

They all use a third-party package called [torchsearchsorted](https://github.com/aliutkus/torchsearchsorted) to sort the `x_b` into the correct bin.
This has the advantage over the numpy version in that, even if the bin boundaries vary within the batch, it can still sort the entire batch in one go.

However, this does require reshaping the `x_b` tensor into a tensor of dimensions `(n_batch * size_half, 1)` so that the sorting can be done with one call to `searchsorted`. It does make me uneasy to mix the batch and lattice dimensions, but it's just for one step and it's a lot faster than looping!

One thing I haven't done is check for a valid base distribution - currently if you use the linear or quadratic splines with any base distribution not defined on [0, 1] it will break. Perhaps this is a good time to us reportengine checks?

---

If we wanted to improve performance we could, in future, try the "one blob encoding" discussed in the https://arxiv.org/pdf/1808.03856.pdf, which involves replacing a single 'x' with a Gaussian that activates several bins at once.