### PR TITLE
[Do not merge] Extend post-processing and plotting to act on intermediate layers of model

### DIFF
--- a/anvil/benchmark_config/free_scalar_sample.yml
+++ b/anvil/benchmark_config/free_scalar_sample.yml
@@ -1,5 +1,6 @@
 training_output: /tmp/del_me_anvil_benchmark
 cp_id: -1
+layer_id: -1
 
 sample_size: 100000
 thermalization: 10
@@ -16,9 +17,6 @@ template_text: |
  # Eigenvalues of kinetic operator
  {@plot_kinetic_eigenvalues@}
  {@table_kinetic_eigenvalues@}
- # Layer-wise breakdown
- {@plot_layerwise_histograms@}
- {@plot_layerwise_weights@}
 
 actions_:
   - report(main=True)

--- a/anvil/benchmark_config/free_scalar_sample.yml
+++ b/anvil/benchmark_config/free_scalar_sample.yml
@@ -16,6 +16,9 @@ template_text: |
  # Eigenvalues of kinetic operator
  {@plot_kinetic_eigenvalues@}
  {@table_kinetic_eigenvalues@}
+ # Layer-wise breakdown
+ {@plot_layerwise_histograms@}
+ {@plot_layerwise_weights@}
 
 actions_:
   - report(main=True)

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -4,14 +4,15 @@ models.py
 Module containing reportengine actions which return callable objects that execute
 normalising flows constructed from multiple layers via function composition.
 """
+import torch
 from functools import partial
+from reportengine import collect
 
 from anvil.core import Sequential
-
 import anvil.layers as layers
 
 
-def coupling_pair(coupling_layer, size_half, **layer_spec):
+def coupling_block(coupling_layer, size_half, **layer_spec):
     """Helper function which returns a callable object that performs a coupling
     transformation on both even and odd lattice sites."""
     coupling_transformation = partial(coupling_layer, size_half, **layer_spec)
@@ -31,7 +32,7 @@ def real_nvp(
     """Action that returns a callable object that performs a sequence of `n_affine`
     affine coupling transformations on both partitions of the input vector."""
     blocks = [
-        coupling_pair(
+        coupling_block(
             layers.AffineLayer,
             size_half,
             hidden_shape=hidden_shape,
@@ -53,7 +54,7 @@ def nice(
     """Action that returns a callable object that performs a sequence of `n_affine`
     affine coupling transformations on both partitions of the input vector."""
     blocks = [
-        coupling_pair(
+        coupling_block(
             layers.AdditiveLayer,
             size_half,
             hidden_shape=hidden_shape,
@@ -74,10 +75,10 @@ def rational_quadratic_spline(
     activation="tanh",
     z2_equivar_spline=False,
 ):
-    """Action that returns a callable object that performs a pair of circular spline
+    """Action that returns a callable object that performs a block of circular spline
     transformations, one on each half of the input vector."""
     blocks = [
-        coupling_pair(
+        coupling_block(
             layers.RationalQuadraticSplineLayer,
             size_half,
             interval=interval,
@@ -96,12 +97,25 @@ def rational_quadratic_spline(
 
 
 def spline_affine(real_nvp, rational_quadratic_spline):
-    return Sequential(rational_quadratic_spline, real_nvp)
+    return Sequential(*rational_quadratic_spline, *real_nvp)
 
 
 def affine_spline(real_nvp, rational_quadratic_spline):
-    return Sequential(real_nvp, rational_quadratic_spline)
+    return Sequential(*real_nvp, *rational_quadratic_spline)
 
+# TODO replace this
+_loaded_model = collect("loaded_model", ("training_context",))
+
+
+def model_weights(_loaded_model):
+    model = _loaded_model[0]
+
+    for block in model:
+        params = {
+            key: tensor.flatten().numpy() for key, tensor in block.state_dict().items()
+        }
+        if len(params) > 1:  # only want coupling layers
+            yield params
 
 MODEL_OPTIONS = {
     "nice": nice,

--- a/anvil/observables.py
+++ b/anvil/observables.py
@@ -12,6 +12,7 @@ import scipy.optimize as optim
 
 log = logging.getLogger(__name__)
 
+
 def cosh_shift(x, xi, A, c):
     return A * np.cosh(-x / xi) + c
 
@@ -42,8 +43,11 @@ def fit_zero_momentum_correlator(zero_momentum_correlator, training_geometry):
 
 
 def correlation_length_from_fit(fit_zero_momentum_correlator):
-    popt, pcov, _ = fit_zero_momentum_correlator
-    return popt[0], np.sqrt(pcov[0, 0])
+    if fit_zero_momentum_correlator is not None:
+        popt, pcov, _ = fit_zero_momentum_correlator
+        return popt[0], np.sqrt(pcov[0, 0])
+    else:
+        return None, None
 
 
 def autocorrelation(chain):

--- a/anvil/plot.py
+++ b/anvil/plot.py
@@ -32,19 +32,28 @@ def plot_layerwise_weights(plot_layer_weights):
     yield from plot_layer_weights
 
 
-def plot_layer_histogram(layerwise_configs):
-    for v in layerwise_configs:
-        v = v.numpy()
-        v_pos = v[v.sum(axis=1) > 0].flatten()
-        v_neg = v[v.sum(axis=1) < 0].flatten()
-        fig, ax = plt.subplots()
-        ax.hist([v_pos, v_neg], bins=50, density=True, histtype="step")
-        yield fig
+@figure
+def plot_layer_histogram(configs):
+    v = configs.numpy()
+    v_pos = v[v.sum(axis=1) > 0].flatten()
+    v_neg = v[v.sum(axis=1) < 0].flatten()
+    fig, ax = plt.subplots()
+    ax.hist([v_pos, v_neg], bins=50, density=True, histtype="step")
+    return fig
 
 
-@figuregen
-def plot_layerwise_histograms(plot_layer_histogram):
-    yield from plot_layer_histogram
+@figure
+def plot_correlation_length(table_correlation_length):
+    fig, ax = plt.subplots()
+    ax.errorbar(
+        x=table_correlation_length.index,
+        y=table_correlation_length.value,
+        yerr=table_correlation_length.error,
+        linestyle="",
+        marker="o",
+    )
+    ax.set_xticklabels(table_correlation_length.index, rotation=45)
+    return fig
 
 
 @figure
@@ -63,14 +72,14 @@ def plot_zero_momentum_correlator(
 
     if fit_zero_momentum_correlator is not None:
         popt, pcov, t0 = fit_zero_momentum_correlator
-        shift = popt[2]
+        xi, A, shift = popt
 
         t = np.linspace(t0, T - t0, 100)
         ax.plot(
             t,
-            cosh_shift(t - T // 2, *popt) - popt[2],
+            cosh_shift(t - T // 2, *popt) - shift,
             "r--",
-            label=r"fit $A \cosh(-(t - T/2) / \xi) + c$",
+            label=r"fit $A \cosh(-(t - T/2) / \xi) + c$" + "\n" + fr"$\xi = ${xi:.2f}",
         )
     ax.errorbar(
         x=np.arange(T),

--- a/anvil/sample.py
+++ b/anvil/sample.py
@@ -120,7 +120,9 @@ def metropolis_hastings(
                 history.append(0)
 
         tau = calc_tau_chain(history)
-        log.info(f"Integrated autocorrelation time from preliminary sampling phase: {tau:.2g}")
+        log.info(
+            f"Integrated autocorrelation time from preliminary sampling phase: {tau:.2g}"
+        )
         sample_interval = ceil(2 * tau)  # update sample interval
 
     log.info(f"Using sampling interval: {sample_interval}")
@@ -180,3 +182,28 @@ def tau_chain(_metropolis_hastings):
 
 def acceptance(_metropolis_hastings):
     return _metropolis_hastings[0][2]
+
+
+# TODO: figure out how to name each coupling block
+@torch.no_grad()
+def yield_configs_layerwise(loaded_model, base_dist, metropolis_hastings):
+    v, _ = base_dist(BATCH_SIZE)
+    yield v
+
+    negative_mag = (v.sum(dim=1).sign() < 0).nonzero().squeeze()
+
+    for block in loaded_model:
+        v, _ = block(v, 0, negative_mag)
+        # only want coupling layers
+        if len([tensor for tensor in block.state_dict().values()]) > 1:
+            yield v
+
+    v = metropolis_hastings[0]
+    yield v
+
+
+_layerwise_configs = collect("yield_configs_layerwise", ("training_context",))
+
+
+def layerwise_configs(_layerwise_configs):
+    return _layerwise_configs[0]

--- a/anvil/table.py
+++ b/anvil/table.py
@@ -42,6 +42,9 @@ def table_fit(fit_zero_momentum_correlator, training_geometry):
             index=["xi_fit", "m_fit"],
         )
         return df
+    else:
+        # TODO should fail better than this
+        return pd.DataFrame([])
 
 
 @table
@@ -100,7 +103,7 @@ def table_correlation_length(
 
     df = pd.DataFrame(
         res,
-        columns=["Mean", "Standard deviation"],
+        columns=["value", "error"],
         index=[
             "Estimate from fit",
             "Estimate using arcosh",
@@ -108,7 +111,7 @@ def table_correlation_length(
             "Low momentum estimate",
         ],
     )
-    df["No. correlation lengths"] = training_geometry.length / df["Mean"]
+    df["No. correlation lengths"] = training_geometry.length / df["value"]
     return df
 
 

--- a/anvil/tests/test_distributions.py
+++ b/anvil/tests/test_distributions.py
@@ -5,7 +5,7 @@ Test distributions module
 from math import sqrt
 
 import numpy as np
-from anvil.distributions import Gaussian
+from anvil.distributions import NormalDist
 
 MEAN = 0
 SIGMA = 1
@@ -20,7 +20,7 @@ def test_normal_distribution():
 
     """
     lattice_size = 5
-    generator = Gaussian(lattice_size, sigma=SIGMA, mean=MEAN)
+    generator = NormalDist(lattice_size, sigma=SIGMA, mean=MEAN)
     sample_pt, _ = generator(N_SAMPLE)
     sample_np = sample_pt.detach().numpy()
     np.testing.assert_allclose(

--- a/anvil/tests/test_distributions.py
+++ b/anvil/tests/test_distributions.py
@@ -5,7 +5,7 @@ Test distributions module
 from math import sqrt
 
 import numpy as np
-from anvil.distributions import NormalDist
+from anvil.distributions import Gaussian
 
 MEAN = 0
 SIGMA = 1
@@ -20,7 +20,7 @@ def test_normal_distribution():
 
     """
     lattice_size = 5
-    generator = NormalDist(lattice_size, sigma=SIGMA, mean=MEAN)
+    generator = Gaussian(lattice_size, sigma=SIGMA, mean=MEAN)
     sample_pt, _ = generator(N_SAMPLE)
     sample_np = sample_pt.detach().numpy()
     np.testing.assert_allclose(

--- a/examples/runcards/layerwise.md
+++ b/examples/runcards/layerwise.md
@@ -1,0 +1,30 @@
+Layer-wise breakdown
+====================
+
+Model weights
+-------------
+{@plot_layerwise_weights@}
+
+Field variables
+---------------
+{@with layer_ids@}
+{@plot_layer_histogram@}
+{@endwith@}
+
+Correlation function
+--------------------
+{@with layer_ids@}
+{@plot_two_point_correlator@}
+{@endwith@}
+
+Correlation function at zero momentum
+-------------------------------------
+{@with layer_ids@}
+{@plot_zero_momentum_correlator@}
+{@endwith@}
+
+Correlation length
+------------------
+{@with layer_ids@}
+{@plot_correlation_length@}
+{@endwith@}

--- a/examples/runcards/layerwise.yml
+++ b/examples/runcards/layerwise.yml
@@ -1,19 +1,19 @@
 training_output: train
 cp_id: -1
-layer_id: -1
+layer_ids: [1, 2, 3, -1]
 
 sample_size: 10000
-thermalization: 10
+thermalization: 1000
 sample_interval: 1
 
-bootstrap_sample_size: 1000
+bootstrap_sample_size: 100
 
 meta:
   author: Author
   title: Training Report
   keywords: [example]
 
-template: report.md
+template: layerwise.md
 
 actions_:
-  - report(main=True)
+    - report(main=True)

--- a/examples/runcards/report.md
+++ b/examples/runcards/report.md
@@ -16,3 +16,6 @@
 {@plot_magnetization_series@}
 {@plot_magnetization_autocorr@}
 {@plot_magnetization_integrated_autocorr@}
+## Layer-wise breakdown
+{@plot_layerwise_histograms@}
+{@plot_layerwise_weights@}

--- a/examples/runcards/report.md
+++ b/examples/runcards/report.md
@@ -10,12 +10,10 @@
 {@plot_zero_momentum_correlator@}
 ## Correlation length
 {@plot_effective_pole_mass@}
+{@plot_correlation_length@}
 {@table_correlation_length@}
 ## Magnetisation
 {@table_magnetization@}
 {@plot_magnetization_series@}
 {@plot_magnetization_autocorr@}
 {@plot_magnetization_integrated_autocorr@}
-## Layer-wise breakdown
-{@plot_layerwise_histograms@}
-{@plot_layerwise_weights@}

--- a/examples/runcards/sample.yml
+++ b/examples/runcards/sample.yml
@@ -1,5 +1,6 @@
 training_output: train
 cp_id: -1
+layer_id: -1
 
 sample_size: 10000
 thermalization: 1000


### PR DESCRIPTION
Phase 1:
- [x] Action that yields model parameters (weights and biases) layer-by-layer
- [x] Action that yields batches of configurations layer-by-layer (including base and Metropolis output)
- [x] Implement basic plotting
- [ ] Subplots to separate weights from different networks, if interesting

Phase 2:
- [x] Add runcard parameter `layer_id` to allow looping the entire analysis (including correlation functions, bootstrapping etc) over each layer in the model
- [ ] Tables + save to .csv as well as the usual plots
- [ ] Write script that reads in data from saved .csv and plots all of the layer on a single figure

Ambitions:
- Instead of just numbers, it would be nice if `layer_id` could refer to an attribute of the layers in the model. E.g., if I wanted to plot the spline layer and the MCMC output I could write `layer_ids: [spline, metropolis]`.
- Better labelling of layers in the report.