### PR TITLE
Improve training context

### DIFF
--- a/anvil/benchmark_config/free_scalar_train.yml
+++ b/anvil/benchmark_config/free_scalar_train.yml
@@ -3,14 +3,10 @@ lattice_length: 6
 lattice_dimension: 2
 
 # Target
-target: phi_four
 parameterisation: standard
 couplings:
     m_sq: 4
     g: 0
-
-# Model
-base: gaussian
 
 model:
   - layer: nice

--- a/anvil/checks.py
+++ b/anvil/checks.py
@@ -11,11 +11,11 @@ correct configuration is used before executing any actions
 from reportengine.checks import make_argcheck, CheckError
 
 @make_argcheck
-def check_trained_with_free_theory(training_context):
+def check_trained_with_free_theory(training_target_dist):
     """Check that supplied model is a free theory model which in the case of
     phi^4 means that lambda = 0
     """
-    if training_context["lam"] != 0:
+    if training_target_dist.c_quartic != 0:
         raise CheckError(
             f"Theory parameters do not correspond to free theory with lam = {lam} "
             "(should be 0)"

--- a/anvil/checks.py
+++ b/anvil/checks.py
@@ -17,6 +17,6 @@ def check_trained_with_free_theory(training_target_dist):
     """
     if training_target_dist.c_quartic != 0:
         raise CheckError(
-            f"Theory parameters do not correspond to free theory with lam = {lam} "
-            "(should be 0)"
+            f"Theory parameters do not correspond to free theory. Quartic term "
+            f"should be 0 and is instead = {training_target_dist.c_quartic}."
         )

--- a/anvil/distributions.py
+++ b/anvil/distributions.py
@@ -244,26 +244,3 @@ class PhiFourScalar:
         See :py:mod:`anvil.distributions.PhiFourScalar.action`
         """
         return -self.action(phi)
-
-
-def gaussian(lattice_size, loc: (int, float) = 0, sigma: (int, float) = 1) -> Gaussian:
-    """Uses arguments to instantiate :py:class:`anvil.distributions.Gaussian`"""
-    return Gaussian(lattice_size, loc=loc, scale=sigma)
-
-
-def phi_four(
-    geometry,
-    parameterisation: str,
-    couplings: dict,
-):
-    """Uses arguments to instantiate :py:class:`anvil.distributions.PhiFourScalar`"""
-    constructor = getattr(PhiFourScalar, f"from_{parameterisation}")
-    return constructor(geometry, **couplings)
-
-
-BASE_OPTIONS = {
-    "gaussian": gaussian,
-}
-TARGET_OPTIONS = {
-    "phi_four": phi_four,
-}

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -294,6 +294,33 @@ def model_to_load(_normalizing_flow) -> layers.Sequential:
     flow_flat = [block for layer in _normalizing_flow for block in layer]
     return layers.Sequential(*flow_flat)
 
+# annoyingly, the api may not have a training output. In which case
+# load model from explicitly declared params.
+_api_normalizing_flow = collect("layer_action", ("model",))
+
+def explicit_model(_api_normalizing_flow):
+    """Action to be called from the API. Build model from an explicit
+    specification, with same input as a training runcard config.
+
+    Examples
+    --------
+
+    >>> from anvil.api import API
+    >>> model_spec = {
+    ...     "model": [
+    ...         {"layer": "global_rescaling", "scale": 1.0},
+    ...         {"layer": "global_rescaling", "scale": 1.0},
+    ...     ]
+    ... }
+    >>> API.explicit_model(**model_spec)
+    Sequential(
+      (0): GlobalRescaling()
+      (1): GlobalRescaling()
+    )
+
+    """
+    # Note: use same action as train/sample apps, so that tests can cover these.
+    return model_to_load(_api_normalizing_flow)
 
 # Update docstring above if you add to this!
 LAYER_OPTIONS = {

--- a/anvil/models.py
+++ b/anvil/models.py
@@ -238,10 +238,10 @@ def global_rescaling(scale: (int, float), learnable: bool = True) -> layers.Sequ
     return layers.Sequential(layers.GlobalRescaling(scale=scale, learnable=learnable))
 
 
-_normalising_flow = collect("layer_action", ("model",))
+# collect layers from copied runcard
+_normalizing_flow = collect("layer_action", ("training_context", "model",))
 
-
-def model_to_load(_normalising_flow) -> layers.Sequential:
+def model_to_load(_normalizing_flow) -> layers.Sequential:
     """action which wraps a list of layers in
     :py:class:`anvil.layers.Sequential`. This allows the user to specify an
     arbitrary combination of layers as the model.
@@ -287,11 +287,11 @@ def model_to_load(_normalising_flow) -> layers.Sequential:
     ``anvil-train`` will also provide the same information.
 
     """
-    # assume that _normalising_flow is a list of layers, each layer
+    # assume that _normalizing_flow is a list of layers, each layer
     # is a sequential of blocks, each block is a pair of transformations
     # which transforms the entire input state - flatten this out, so output
     # is Sequential of blocks
-    flow_flat = [block for layer in _normalising_flow for block in layer]
+    flow_flat = [block for layer in _normalizing_flow for block in layer]
     return layers.Sequential(*flow_flat)
 
 

--- a/anvil/plot.py
+++ b/anvil/plot.py
@@ -6,15 +6,14 @@ plot.py
 module containing all actions for plotting observables
 
 """
-import torch
+
 import numpy as np
 import matplotlib.pyplot as plt
-import matplotlib as mpl
-from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
+from matplotlib.colors import SymLogNorm
 from matplotlib.font_manager import FontProperties
+from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
 
 from reportengine.figure import figure, figuregen
-from reportengine import collect
 
 from anvil.observables import cosh_shift
 
@@ -261,7 +260,7 @@ def plot_two_point_correlator(two_point_correlator):
     ax.set_xticklabels(tick_labels)
     ax.set_yticklabels(tick_labels)
 
-    norm = mpl.colors.SymLogNorm(linthresh=0.01, base=10)
+    norm = SymLogNorm(linthresh=0.01, base=10)
     im = ax.imshow(corr, norm=norm)
     fig.colorbar(im, ax=ax, pad=0.01)
 

--- a/anvil/tests/test_models.py
+++ b/anvil/tests/test_models.py
@@ -55,12 +55,12 @@ def test_model_construction(layer_idx, n_blocks, lattice_length_half, hidden_sha
     }
     # might help with memory.
     with torch.no_grad():
-        API.model_to_load(**params)
+        API.explicit_model(**params)
 
 
 def layer_independence_test(model_spec):
     """Check that each layer's parameters are updated independently."""
-    model = iter(API.model_to_load(**model_spec))
+    model = iter(API.explicit_model(**model_spec))
     model_copy = deepcopy(model)
 
     # Update parameters in first layer

--- a/examples/runcards/train.yml
+++ b/examples/runcards/train.yml
@@ -3,14 +3,10 @@ lattice_length: 6
 lattice_dimension: 2
 
 # Target
-target: phi_four
 parameterisation: albergo2019
 couplings:
     m_sq: -4
     lam: 6.975
-
-# Model
-base: gaussian
 
 model:
  - layer: real_nvp
@@ -45,4 +41,3 @@ optimizer_params:
 scheduler: CosineAnnealingLR
 scheduler_params:
     T_max: 2000
-


### PR DESCRIPTION
As discussed, I have added some `training_<key>` where key refers to a namespace key with a production rule - things like `base_dist` etc.

Since we don't actually have options for base or target I just removed the explicit node stuff there. Even if there was a choice, we don't technically need it because we could just have the logic that chose the action inside that production rule.

I then have changed the model to load from the training_context. This didn't break much apart from the tests, because when you use the API there is no training output but you may want to declare a model - in this instance there is a new function called `explicit_model` which should be called. This might mean that some examples or docs are out of date (already!) but we can worry about that after we agree this approach is what we want.

The train, report, and benchmark all seem to be working fine with this. Let me know what you think.

closes #62 